### PR TITLE
Terrain quad tree

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -59,13 +59,13 @@ pub fn build(b: *Builder) void {
     install_meshes_step.step.dependOn(dxc_step);
     exe.step.dependOn(&install_meshes_step.step);
 
-    const install_textures_step = b.addInstallDirectory(.{
-        .source_dir = thisDir() ++ "/content/textures",
+    const install_patches_step = b.addInstallDirectory(.{
+        .source_dir = thisDir() ++ "/content/patch",
         .install_dir = .{ .custom = "" },
-        .install_subdir = "bin/content/textures",
+        .install_subdir = "bin/content/patch",
     });
-    install_textures_step.step.dependOn(dxc_step);
-    exe.step.dependOn(&install_textures_step.step);
+    install_patches_step.step.dependOn(dxc_step);
+    exe.step.dependOn(&install_patches_step.step);
 
     // This is needed to export symbols from an .exe file.
     // We export D3D12SDKVersion and D3D12SDKPath symbols which

--- a/build.zig
+++ b/build.zig
@@ -50,13 +50,21 @@ pub fn build(b: *Builder) void {
     install_shaders_step.step.dependOn(dxc_step);
     exe.step.dependOn(&install_shaders_step.step);
 
-    const install_content_step = b.addInstallDirectory(.{
+    const install_meshes_step = b.addInstallDirectory(.{
         .source_dir = thisDir() ++ "/content/meshes",
         .install_dir = .{ .custom = "" },
         .install_subdir = "bin/content/meshes",
     });
-    install_content_step.step.dependOn(dxc_step);
-    exe.step.dependOn(&install_content_step.step);
+    install_meshes_step.step.dependOn(dxc_step);
+    exe.step.dependOn(&install_meshes_step.step);
+
+    const install_textures_step = b.addInstallDirectory(.{
+        .source_dir = thisDir() ++ "/content/textures",
+        .install_dir = .{ .custom = "" },
+        .install_subdir = "bin/content/textures",
+    });
+    install_textures_step.step.dependOn(dxc_step);
+    exe.step.dependOn(&install_textures_step.step);
 
     // This is needed to export symbols from an .exe file.
     // We export D3D12SDKVersion and D3D12SDKPath symbols which

--- a/build.zig
+++ b/build.zig
@@ -42,10 +42,18 @@ pub fn build(b: *Builder) void {
     const zd3d12_pkg = zd3d12.getPkg(&.{ zwin32.pkg, zd3d12_options.getPkg() });
 
     const dxc_step = buildShaders(b);
-    const install_content_step = b.addInstallDirectory(.{
+    const install_shaders_step = b.addInstallDirectory(.{
         .source_dir = thisDir() ++ "/src/shaders/compiled",
         .install_dir = .{ .custom = "" },
         .install_subdir = "bin/shaders",
+    });
+    install_shaders_step.step.dependOn(dxc_step);
+    exe.step.dependOn(&install_shaders_step.step);
+
+    const install_content_step = b.addInstallDirectory(.{
+        .source_dir = thisDir() ++ "/content/meshes",
+        .install_dir = .{ .custom = "" },
+        .install_subdir = "bin/content/meshes",
     });
     install_content_step.step.dependOn(dxc_step);
     exe.step.dependOn(&install_content_step.step);
@@ -101,6 +109,11 @@ fn buildShaders(b: *std.build.Builder) *std.build.Step {
     dxc_command = makeDxcCmd("src/shaders/instanced.hlsl", "vsInstanced", "instanced.vs.cso", "vs", "");
     dxc_step.dependOn(&b.addSystemCommand(&dxc_command).step);
     dxc_command = makeDxcCmd("src/shaders/instanced.hlsl", "psInstanced", "instanced.ps.cso", "ps", "");
+    dxc_step.dependOn(&b.addSystemCommand(&dxc_command).step);
+
+    dxc_command = makeDxcCmd("src/shaders/terrain_quad_tree.hlsl", "vsTerrainQuadTree", "terrain_quad_tree.vs.cso", "vs", "");
+    dxc_step.dependOn(&b.addSystemCommand(&dxc_command).step);
+    dxc_command = makeDxcCmd("src/shaders/terrain_quad_tree.hlsl", "psTerrainQuadTree", "terrain_quad_tree.ps.cso", "ps", "");
     dxc_step.dependOn(&b.addSystemCommand(&dxc_command).step);
 
     return dxc_step;

--- a/src/config.zig
+++ b/src/config.zig
@@ -16,6 +16,8 @@ pub const input_move_left = IdLocal.init("move_left");
 pub const input_move_right = IdLocal.init("move_right");
 pub const input_move_forward = IdLocal.init("move_forward");
 pub const input_move_backward = IdLocal.init("move_backward");
+pub const input_move_up = IdLocal.init("move_up");
+pub const input_move_down = IdLocal.init("move_down");
 pub const input_move_slow = IdLocal.init("move_slow");
 pub const input_move_fast = IdLocal.init("move_fast");
 

--- a/src/fsm/camera/state_camera_freefly.zig
+++ b/src/fsm/camera/state_camera_freefly.zig
@@ -33,9 +33,12 @@ fn updateMovement(pos: *fd.Position, rot: *fd.EulerRotation, dt: zm.F32x4, input
     const speed = zm.f32x4s(speed_scalar);
     const transform = zm.mul(zm.rotationX(rot.pitch), zm.rotationY(rot.yaw));
     var forward = zm.util.getAxisZ(transform);
+    var right = zm.normalize3(zm.cross3(zm.f32x4(0.0, 1.0, 0.0, 0.0), forward));
+    var up = zm.normalize3(zm.cross3(forward, right));
 
-    const right = speed * dt * zm.normalize3(zm.cross3(zm.f32x4(0.0, 1.0, 0.0, 0.0), forward));
+    right = speed * dt * right;
     forward = speed * dt * forward;
+    up = speed * dt * up;
 
     var cpos = zm.load(pos.elems()[0..], zm.Vec, 3);
 
@@ -49,6 +52,12 @@ fn updateMovement(pos: *fd.Position, rot: *fd.EulerRotation, dt: zm.F32x4, input
         cpos += right;
     } else if (input_state.held(config.input_move_left)) {
         cpos -= right;
+    }
+
+    if (input_state.held(config.input_move_up)) {
+        cpos += up;
+    } else if (input_state.held(config.input_move_down)) {
+        cpos -= up;
     }
 
     zm.store(pos.elems()[0..], cpos, 3);

--- a/src/game.zig
+++ b/src/game.zig
@@ -55,11 +55,13 @@ pub fn run() void {
 
     const input_target_defaults = blk: {
         var itm = input.TargetMap.init(std.heap.page_allocator);
-        itm.ensureUnusedCapacity(16) catch unreachable;
+        itm.ensureUnusedCapacity(18) catch unreachable;
         itm.putAssumeCapacity(config.input_move_left, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_move_right, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_move_forward, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_move_backward, input.TargetValue{ .number = 0 });
+        itm.putAssumeCapacity(config.input_move_up, input.TargetValue{ .number = 0 });
+        itm.putAssumeCapacity(config.input_move_down, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_move_slow, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_interact, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_move_fast, input.TargetValue{ .number = 0 });
@@ -80,11 +82,13 @@ pub fn run() void {
             .bindings = std.ArrayList(input.Binding).init(std.heap.page_allocator),
             .processors = std.ArrayList(input.Processor).init(std.heap.page_allocator),
         };
-        keyboard_map.bindings.ensureTotalCapacity(16) catch unreachable;
+        keyboard_map.bindings.ensureTotalCapacity(18) catch unreachable;
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_left, .source = input.BindingSource{ .keyboard_key = .a } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_right, .source = input.BindingSource{ .keyboard_key = .d } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_forward, .source = input.BindingSource{ .keyboard_key = .w } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_backward, .source = input.BindingSource{ .keyboard_key = .s } });
+        keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_up, .source = input.BindingSource{ .keyboard_key = .e } });
+        keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_down, .source = input.BindingSource{ .keyboard_key = .q } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_slow, .source = input.BindingSource{ .keyboard_key = .left_control } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_fast, .source = input.BindingSource{ .keyboard_key = .left_shift } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_interact, .source = input.BindingSource{ .keyboard_key = .e } });

--- a/src/game.zig
+++ b/src/game.zig
@@ -11,6 +11,7 @@ const city_system = @import("systems/procgen/city_system.zig");
 const input_system = @import("systems/input_system.zig");
 const input = @import("input.zig");
 const physics_system = @import("systems/physics_system.zig");
+const terrain_quad_tree_system = @import("systems/terrain_quad_tree.zig");
 const procmesh_system = @import("systems/procedural_mesh_system.zig");
 const state_machine_system = @import("systems/state_machine_system.zig");
 const terrain_system = @import("systems/terrain_system.zig");
@@ -197,6 +198,14 @@ pub fn run() void {
         &input_frame_data,
     );
     defer camera_system.destroy(camera_sys);
+
+    var terrain_quad_tree_sys = try terrain_quad_tree_system.create(
+        IdLocal.initFormat("terrain_quad_tree_system{}", .{0}),
+        std.heap.page_allocator,
+        &gfx_state,
+        &flecs_world,
+    );
+    defer terrain_quad_tree_system.destroy(terrain_quad_tree_sys);
 
     var procmesh_sys = try procmesh_system.create(
         IdLocal.initFormat("procmesh_system_{}", .{0}),

--- a/src/game.zig
+++ b/src/game.zig
@@ -98,7 +98,7 @@ pub fn run() void {
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_down, .source = input.BindingSource{ .keyboard_key = .q } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_slow, .source = input.BindingSource{ .keyboard_key = .left_control } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_move_fast, .source = input.BindingSource{ .keyboard_key = .left_shift } });
-        keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_interact, .source = input.BindingSource{ .keyboard_key = .e } });
+        keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_interact, .source = input.BindingSource{ .keyboard_key = .f } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_camera_switch, .source = input.BindingSource{ .keyboard_key = .tab } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_exit, .source = input.BindingSource{ .keyboard_key = .escape } });
 

--- a/src/game.zig
+++ b/src/game.zig
@@ -279,14 +279,6 @@ pub fn run() void {
     );
     defer camera_system.destroy(camera_sys);
 
-    var terrain_quad_tree_sys = try terrain_quad_tree_system.create(
-        IdLocal.initFormat("terrain_quad_tree_system{}", .{0}),
-        std.heap.page_allocator,
-        &gfx_state,
-        &flecs_world,
-    );
-    defer terrain_quad_tree_system.destroy(terrain_quad_tree_sys);
-
     var procmesh_sys = try procmesh_system.create(
         IdLocal.initFormat("procmesh_system_{}", .{0}),
         std.heap.page_allocator,

--- a/src/gfx_d3d12.zig
+++ b/src/gfx_d3d12.zig
@@ -303,8 +303,8 @@ pub fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !D3D12State {
 
     var gctx = zd3d12.GraphicsContext.init(allocator, hwnd);
     // Enable vsync.
-    // gctx.present_flags = 0;
-    // gctx.present_interval = 1;
+    gctx.present_flags = .{ .ALLOW_TEARING = false };
+    gctx.present_interval = 1;
 
     var buffer_pool = BufferPool.init(allocator);
     var texture_pool = TexturePool.init(allocator);

--- a/src/gfx_d3d12.zig
+++ b/src/gfx_d3d12.zig
@@ -24,7 +24,7 @@ const BufferPool = buffer_module.BufferPool;
 pub const BufferDesc = buffer_module.BufferDesc;
 pub const BufferHandle = buffer_module.BufferHandle;
 
-const Texture = texture_module.Texture;
+pub const Texture = texture_module.Texture;
 const TexturePool = texture_module.TexturePool;
 pub const TextureDesc = texture_module.TextureDesc;
 pub const TextureHandle = texture_module.TextureHandle;
@@ -199,8 +199,11 @@ pub const D3D12State = struct {
         self.gctx.beginFrame();
 
         const resource = self.gctx.createAndUploadTex2dFromFile(path, .{}) catch |err| hrPanic(err);
-        // TODO
-        // _ = self.gctx.lookupResource(resource).?.SetName(textureDesc.name);
+        var path_u16: [300]u16 = undefined;
+        assert(path.len < path_u16.len - 1);
+        const path_len = std.unicode.utf8ToUtf16Le(path_u16[0..], path) catch unreachable;
+        path_u16[path_len] = 0;
+        _ = self.gctx.lookupResource(resource).?.SetName(path_u16);
 
         const texture = blk: {
             const srv_allocation = self.gctx.allocatePersistentGpuDescriptors(1);

--- a/src/gfx_d3d12.zig
+++ b/src/gfx_d3d12.zig
@@ -460,7 +460,7 @@ pub fn deinit(self: *D3D12State, allocator: std.mem.Allocator) void {
     self.gpu_profiler.deinit();
 
     self.buffer_pool.deinit(allocator, &self.gctx);
-    self.texture_pool.deinit(allocator, &self.gctx);
+    self.texture_pool.deinit(allocator);
 
     // Destroy all pipelines
     {

--- a/src/gfx_d3d12.zig
+++ b/src/gfx_d3d12.zig
@@ -287,6 +287,26 @@ pub fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !D3D12State {
         );
     };
 
+    const terrain_quad_tree_pipeline = blk: {
+        var pso_desc = d3d12.GRAPHICS_PIPELINE_STATE_DESC.initDefault();
+        pso_desc.InputLayout = .{
+            .pInputElementDescs = null,
+            .NumElements = 0,
+        };
+        pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
+        pso_desc.NumRenderTargets = 1;
+        pso_desc.DSVFormat = .D32_FLOAT;
+        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
+        pso_desc.PrimitiveTopologyType = .TRIANGLE;
+
+        break :blk gctx.createGraphicsShaderPipeline(
+            arena,
+            &pso_desc,
+            "shaders/terrain_quad_tree.vs.cso",
+            "shaders/terrain_quad_tree.ps.cso",
+        );
+    };
+
     const terrain_pipeline = blk: {
         // TODO: Replace InputAssembly with vertex fetch in shader
         const input_layout_desc = [_]d3d12.INPUT_ELEMENT_DESC{
@@ -315,6 +335,7 @@ pub fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !D3D12State {
     };
 
     pipelines.put(IdLocal.init("instanced"), PipelineInfo{ .pipeline_handle = instanced_pipeline }) catch unreachable;
+    pipelines.put(IdLocal.init("terrain_quad_tree"), PipelineInfo{ .pipeline_handle = terrain_quad_tree_pipeline }) catch unreachable;
     pipelines.put(IdLocal.init("terrain"), PipelineInfo{ .pipeline_handle = terrain_pipeline }) catch unreachable;
 
     var gpu_profiler = Profiler.init(allocator, &gctx) catch unreachable;

--- a/src/renderer/d3d12/texture.zig
+++ b/src/renderer/d3d12/texture.zig
@@ -10,7 +10,6 @@ pub const TextureDesc = struct {
 };
 
 pub const Texture = struct {
-    // resource: zd3d12.ResourceHandle,
     resource: ?*d3d12.IResource,
     persistent_descriptor: zd3d12.PersistentDescriptor,
 };

--- a/src/renderer/d3d12/texture.zig
+++ b/src/renderer/d3d12/texture.zig
@@ -1,0 +1,123 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const zwin32 = @import("zwin32");
+const d3d12 = zwin32.d3d12;
+const zd3d12 = @import("zd3d12");
+
+pub const TextureDesc = struct {
+    state: d3d12.RESOURCE_STATES, // TODO: Replace this with non-d3d12 state enum
+    name: [*:0]const u16,
+};
+
+pub const Texture = struct {
+    valid: bool = false,
+    resource: zd3d12.ResourceHandle,
+    persistent_descriptor: zd3d12.PersistentDescriptor,
+};
+
+pub const TextureHandle = struct {
+    index: u16 align(4) = 0,
+    generation: u16 = 0,
+};
+
+pub const TexturePool = struct {
+    const max_num_textures = 1024; // TODO: Figure out how many we need as we go
+
+    textures: []Texture,
+    generations: []u16,
+
+    pub fn init(allocator: std.mem.Allocator) TexturePool {
+        return .{
+            .textures = blk: {
+                var textures = allocator.alloc(
+                    Texture,
+                    max_num_textures + 1,
+                ) catch unreachable;
+                for (textures) |*texture| {
+                    texture.* = .{
+                        .resource = undefined,
+                        .persistent_descriptor = undefined,
+                    };
+                }
+                break :blk textures;
+            },
+            .generations = blk: {
+                var generations = allocator.alloc(
+                    u16,
+                    max_num_textures + 1,
+                ) catch unreachable;
+                for (generations) |*gen| gen.* = 0;
+                break :blk generations;
+            },
+        };
+    }
+
+    pub fn deinit(pool: *TexturePool, allocator: std.mem.Allocator, gctx: *zd3d12.GraphicsContext) void {
+        for (pool.textures) |texture| {
+            if (texture.valid) {
+                gctx.destroyResource(texture.resource);
+            }
+        }
+
+        allocator.free(pool.textures);
+        allocator.free(pool.generations);
+        pool.* = undefined;
+    }
+
+    pub fn addTexture(pool: *TexturePool, texture: Texture) TextureHandle {
+        var slot_idx: u32 = 1;
+        while (slot_idx <= max_num_textures) : (slot_idx += 1) {
+            if (!pool.textures[slot_idx].valid)
+                break;
+        }
+        assert(slot_idx <= max_num_textures);
+
+        pool.textures[slot_idx] = .{
+            .valid = true,
+            .resource = texture.resource,
+            .persistent_descriptor = .{
+                .cpu_handle = texture.persistent_descriptor.cpu_handle,
+                .gpu_handle = texture.persistent_descriptor.gpu_handle,
+                .index = texture.persistent_descriptor.index,
+            },
+        };
+        const handle = TextureHandle{
+            .index = @intCast(u16, slot_idx),
+            .generation = blk: {
+                pool.generations[slot_idx] += 1;
+                break :blk pool.generations[slot_idx];
+            },
+        };
+        return handle;
+    }
+
+    pub fn destroyTexture(pool: *TexturePool, handle: TextureHandle, gctx: *zd3d12.GraphicsContext) void {
+        var texture = pool.lookupTexture(handle);
+        if (texture == null)
+            return;
+
+        gctx.destroyResource(texture.?.resource);
+
+        texture.?.* = .{
+            .valid = false,
+            .resource = undefined,
+            .persistent_descriptor = undefined,
+        };
+    }
+
+    fn isTextureValid(pool: TexturePool, handle: TextureHandle) bool {
+        return handle.index > 0 and
+            handle.index <= max_num_textures and
+            handle.generation > 0 and
+            handle.generation == pool.generations[handle.index] and
+            pool.textures[handle.index].valid;
+    }
+
+    pub fn lookupTexture(pool: TexturePool, handle: TextureHandle) ?*Texture {
+        if (pool.isTextureValid(handle)) {
+            return &pool.textures[handle.index];
+        }
+
+        return null;
+    }
+};

--- a/src/renderer/d3d12/texture.zig
+++ b/src/renderer/d3d12/texture.zig
@@ -21,7 +21,7 @@ pub const TextureHandle = struct {
 };
 
 pub const TexturePool = struct {
-    const max_num_textures = 4096; // TODO: Figure out how many we need as we go
+    const max_num_textures = 64 * 85; // TODO: Figure out how many we need as we go
 
     textures: []Texture,
     generations: []u16,

--- a/src/renderer/d3d12/texture.zig
+++ b/src/renderer/d3d12/texture.zig
@@ -52,10 +52,9 @@ pub const TexturePool = struct {
         };
     }
 
-    pub fn deinit(pool: *TexturePool, allocator: std.mem.Allocator, _: *zd3d12.GraphicsContext) void {
+    pub fn deinit(pool: *TexturePool, allocator: std.mem.Allocator) void {
         for (pool.textures) |texture| {
             if (texture.resource != null) {
-                // gctx.destroyResource(texture.resource);
                 _ = texture.resource.?.Release();
             }
         }
@@ -89,19 +88,6 @@ pub const TexturePool = struct {
             },
         };
         return handle;
-    }
-
-    pub fn destroyTexture(pool: *TexturePool, handle: TextureHandle, gctx: *zd3d12.GraphicsContext) void {
-        var texture = pool.lookupTexture(handle);
-        if (texture == null)
-            return;
-
-        gctx.destroyResource(texture.?.resource);
-
-        texture.?.* = .{
-            .resource = null,
-            .persistent_descriptor = undefined,
-        };
     }
 
     fn isTextureValid(pool: TexturePool, handle: TextureHandle) bool {

--- a/src/shaders/common.hlsli
+++ b/src/shaders/common.hlsli
@@ -11,4 +11,10 @@
 
 #define PI 3.1415926
 
+float3 gammaCorrect(float3 color) {
+    float gamma = 1.0 / 2.2;
+    color = pow(color, float3(gamma, gamma, gamma));
+    return color;
+}
+
 #endif

--- a/src/shaders/pbr.hlsli
+++ b/src/shaders/pbr.hlsli
@@ -117,10 +117,4 @@ float3 pbrShading(float3 base_color, PBRInput input, float4 light_positions[MAX_
     return color;
 }
 
-float3 gammaCorrect(float3 color) {
-    float gamma = 1.0 / 2.2;
-    color = pow(color, float3(gamma, gamma, gamma));
-    return color;
-}
-
 #endif

--- a/src/shaders/terrain_quad_tree.hlsl
+++ b/src/shaders/terrain_quad_tree.hlsl
@@ -1,10 +1,20 @@
 #include "common.hlsli"
+#include "pbr.hlsli"
 
+// TODO: Split the static sampler declarations and move them to common.hlsli
 #define ROOT_SIGNATURE \
     "RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED), " \
     "CBV(b0), " \
     "CBV(b1), " \
-    "StaticSampler(s0, filter = FILTER_ANISOTROPIC, maxAnisotropy = 16, visibility = SHADER_VISIBILITY_ALL, addressU = TEXTURE_ADDRESS_CLAMP, addressV = TEXTURE_ADDRESS_CLAMP, addressW = TEXTURE_ADDRESS_CLAMP)"
+    "StaticSampler(s0, filter = FILTER_ANISOTROPIC, maxAnisotropy = 16, visibility = SHADER_VISIBILITY_ALL, addressU = TEXTURE_ADDRESS_CLAMP, addressV = TEXTURE_ADDRESS_CLAMP, addressW = TEXTURE_ADDRESS_CLAMP), " \
+    "StaticSampler(s1, filter = FILTER_ANISOTROPIC, maxAnisotropy = 16, visibility = SHADER_VISIBILITY_ALL, addressU = TEXTURE_ADDRESS_WRAP, addressV = TEXTURE_ADDRESS_WRAP, addressW = TEXTURE_ADDRESS_WRAP), " \
+    "StaticSampler(s2, filter = FILTER_COMPARISON_MIN_MAG_MIP_LINEAR, visibility = SHADER_VISIBILITY_ALL, addressU = TEXTURE_ADDRESS_CLAMP, addressV = TEXTURE_ADDRESS_CLAMP, addressW = TEXTURE_ADDRESS_CLAMP), " \
+    "StaticSampler(s3, filter = FILTER_COMPARISON_MIN_MAG_MIP_LINEAR, visibility = SHADER_VISIBILITY_ALL, addressU = TEXTURE_ADDRESS_WRAP, addressV = TEXTURE_ADDRESS_WRAP, addressW = TEXTURE_ADDRESS_WRAP)"
+
+SamplerState sam_aniso_clamp : register(s0);
+SamplerState sam_aniso_wrap : register(s1);
+SamplerState sam_linear_clamp : register(s2);
+SamplerState sam_linear_wrap : register(s3);
 
 struct Vertex {
     float3 position;
@@ -24,6 +34,12 @@ struct FrameConst {
     float4x4 world_to_clip;
     float3 camera_position;
     float time;
+    uint padding1;
+    uint padding2;
+    uint padding3;
+    uint light_count;
+    float4 light_positions[MAX_LIGHTS];
+    float4 light_radiances[MAX_LIGHTS];
 };
 
 struct InstanceTransform {
@@ -39,12 +55,12 @@ ConstantBuffer<FrameConst> cbv_frame_const : register(b1);
 
 struct InstancedVertexOut {
     float4 position_vs : SV_Position;
+    float3 normal : NORMAL;
     float3 position : TEXCOORD0;
     float2 uv : TEXCOORD1;
     uint instanceID: SV_InstanceID;
 };
 
-SamplerState sam_aniso : register(s0);
 
 [RootSignature(ROOT_SIGNATURE)]
 InstancedVertexOut vsTerrainQuadTree(uint vertex_id : SV_VertexID, uint instanceID : SV_InstanceID) {
@@ -61,7 +77,7 @@ InstancedVertexOut vsTerrainQuadTree(uint vertex_id : SV_VertexID, uint instance
     ByteAddressBuffer instance_material_buffer = ResourceDescriptorHeap[cbv_draw_const.instance_material_buffer_index];
     InstanceMaterial material = instance_material_buffer.Load<InstanceMaterial>(instance_index * sizeof(InstanceMaterial));
     Texture2D heightmap = ResourceDescriptorHeap[material.heightmap_index];
-    float height = heightmap.SampleLevel(sam_aniso, vertex.uv, 0).r;
+    float height = heightmap.SampleLevel(sam_linear_clamp, vertex.uv, 0).r;
 
     float3 displaced_position = vertex.position;
     displaced_position.y = lerp(0.0f, 200.0f, height);    // TODO: Pass min/max heights to shader
@@ -69,6 +85,8 @@ InstancedVertexOut vsTerrainQuadTree(uint vertex_id : SV_VertexID, uint instance
     const float4x4 object_to_clip = mul(instance.object_to_world, cbv_frame_const.world_to_clip);
     output.position_vs = mul(float4(displaced_position, 1.0), object_to_clip);
     output.position = mul(float4(displaced_position, 1.0), instance.object_to_world).xyz;
+
+    output.normal = vertex.normal;
     output.uv = vertex.uv;
 
     return output;
@@ -76,14 +94,57 @@ InstancedVertexOut vsTerrainQuadTree(uint vertex_id : SV_VertexID, uint instance
 
 static const float g_wireframe_smoothing = 1.0;
 static const float g_wireframe_thickness = 0.25;
+static const float2 texel = 1.0f / float2(65.0f, 65.0f);
 
 [RootSignature(ROOT_SIGNATURE)]
-void psTerrainQuadTree(InstancedVertexOut input, float3 barycentrics : SV_Barycentrics, out float4 out_color : SV_Target0) {
-    float3 color = float3(input.uv, 0.0);
+void psTerrainQuadTree(InstancedVertexOut input/*, float3 barycentrics : SV_Barycentrics*/, out float4 out_color : SV_Target0) {
+    float3 base_colors[5] = {
+        float3(0.0, 0.1, 0.7),
+        float3(1.0, 1.0, 0.0),
+        float3(0.3, 0.8, 0.2),
+        float3(0.7, 0.7, 0.7),
+        float3(0.95, 0.95, 0.95),
+    };
+
+    float3 normal = normalize(input.normal);
+
+    // Derive normals from the heightmap 
+    // https://www.shadertoy.com/view/3sSSW1
+    {
+        uint instance_index = input.instanceID + cbv_draw_const.start_instance_location;
+        ByteAddressBuffer instance_material_buffer = ResourceDescriptorHeap[cbv_draw_const.instance_material_buffer_index];
+        InstanceMaterial material = instance_material_buffer.Load<InstanceMaterial>(instance_index * sizeof(InstanceMaterial));
+        Texture2D heightmap = ResourceDescriptorHeap[material.heightmap_index];
+
+        float height = heightmap.Sample(sam_linear_clamp, input.uv).r;
+        float height_h = heightmap.Sample(sam_linear_clamp, input.uv + texel * float2(1.0, 0.0)).r; 
+        float height_v = heightmap.Sample(sam_linear_clamp, input.uv + texel * float2(0.0, 1.0)).r; 
+        float2 n = height - float2(height_h, height_v);
+        n *= 20.0;
+        n += 0.5;
+        normal = normalize(float3(n.xy, 1.0));
+    }
+
+    float3 base_color = base_colors[0];
+    base_color = lerp(base_color, base_colors[1], step(0.005, input.position.y * 0.01));
+    base_color = lerp(base_color, base_colors[2], step(0.02, input.position.y * 0.01));
+    base_color = lerp(base_color, base_colors[3], step(1.0, input.position.y * 0.01 + 0.5 * (1.0 - dot(normal, float3(0.0, 1.0, 0.0))) ));
+    base_color = lerp(base_color, base_colors[4], step(3.5, input.position.y * 0.01 + 1.5 * dot(normal, float3(0.0, 1.0, 0.0)) ));
+
+    PBRInput pbrInput;
+    pbrInput.view_position = cbv_frame_const.camera_position;
+    pbrInput.position = input.position;
+    pbrInput.normal = normal;
+    pbrInput.roughness = 0.5f;
+    pbrInput.time = cbv_frame_const.time;
+
+    float3 color = pbrShading(base_color, pbrInput, cbv_frame_const.light_positions, cbv_frame_const.light_radiances, cbv_frame_const.light_count);
     color = gammaCorrect(color);
     out_color.rgb = color;
     out_color.a = 1;
  
+    // TODO: Pass a flag to the shader to control if we want to 
+    // render the wireframe or not
     // wireframe
     // float3 barys = barycentrics;
     // barys.z = 1.0 - barys.x - barys.y;
@@ -93,8 +154,6 @@ void psTerrainQuadTree(InstancedVertexOut input, float3 barycentrics : SV_Baryce
     // barys = smoothstep(thickness, thickness + smoothing, barys);
     // float min_bary = min(barys.x, min(barys.y, barys.z));
 
-    // TODO: Pass a flag to the shader to control if we want to 
-    // render the wireframe or not
     // color = lerp(float3(0.3, 0.3, 0.3), color, min_bary);
     // min_bary = 1.0;
 

--- a/src/shaders/terrain_quad_tree.hlsl
+++ b/src/shaders/terrain_quad_tree.hlsl
@@ -1,0 +1,79 @@
+#include "common.hlsli"
+
+#define ROOT_SIGNATURE \
+    "RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED), " \
+    "CBV(b0), " \
+    "CBV(b1), "
+
+struct Vertex {
+    float3 position;
+    float2 uv;
+};
+
+struct DrawConst {
+    uint start_instance_location;
+    int vertex_offset;
+    uint vertex_buffer_index;
+    uint instance_transform_buffer_index;
+    uint instance_material_buffer_index;
+};
+
+struct FrameConst {
+    float4x4 world_to_clip;
+    float3 camera_position;
+    float time;
+};
+
+struct InstanceTransform {
+    float4x4 object_to_world;
+};
+
+struct InstanceMaterial {
+    float4 basecolor_roughness;
+};
+
+// ConstantBuffer<DrawConst> cbv_draw_const : register(b0, per_object_space);
+// ConstantBuffer<FrameConst> cbv_frame_const : register(b0, per_pass_space);
+ConstantBuffer<DrawConst> cbv_draw_const : register(b0);
+ConstantBuffer<FrameConst> cbv_frame_const : register(b1);
+
+struct InstancedVertexOut {
+    float4 position_vs : SV_Position;
+    float3 position : TEXCOORD0;
+    float2 uv : TEXCOORD1;
+    uint instanceID: SV_InstanceID;
+};
+
+[RootSignature(ROOT_SIGNATURE)]
+InstancedVertexOut vsTerrainQuadTree(uint vertex_id : SV_VertexID, uint instanceID : SV_InstanceID) {
+    InstancedVertexOut output = (InstancedVertexOut)0;
+    output.instanceID = instanceID;
+
+    ByteAddressBuffer vertex_buffer = ResourceDescriptorHeap[cbv_draw_const.vertex_buffer_index];
+    Vertex vertex = vertex_buffer.Load<Vertex>((vertex_id + cbv_draw_const.vertex_offset) * sizeof(Vertex));
+
+    ByteAddressBuffer instance_transform_buffer = ResourceDescriptorHeap[cbv_draw_const.instance_transform_buffer_index];
+    uint instance_index = instanceID + cbv_draw_const.start_instance_location;
+    InstanceTransform instance = instance_transform_buffer.Load<InstanceTransform>(instance_index * sizeof(InstanceTransform));
+
+    const float4x4 object_to_clip = mul(instance.object_to_world, cbv_frame_const.world_to_clip);
+    output.position_vs = mul(float4(vertex.position, 1.0), object_to_clip);
+    output.position = mul(float4(vertex.position, 1.0), instance.object_to_world).xyz;
+    output.uv = vertex.uv;
+
+    return output;
+}
+
+[RootSignature(ROOT_SIGNATURE)]
+void psTerrainQuadTree(InstancedVertexOut input, out float4 out_color : SV_Target0) {
+    ByteAddressBuffer instance_material_buffer = ResourceDescriptorHeap[cbv_draw_const.instance_material_buffer_index];
+    uint instance_index = input.instanceID + cbv_draw_const.start_instance_location;
+    InstanceMaterial material = instance_material_buffer.Load<InstanceMaterial>(instance_index * sizeof(InstanceMaterial));
+
+    float3 base_color = material.basecolor_roughness.rgb;
+
+    float3 color = float3(input.uv, 0.0);
+    color = gammaCorrect(color);
+    out_color.rgb = color;
+    out_color.a = 1;
+}

--- a/src/shaders/terrain_quad_tree.hlsl
+++ b/src/shaders/terrain_quad_tree.hlsl
@@ -60,13 +60,13 @@ InstancedVertexOut vsTerrainQuadTree(uint vertex_id : SV_VertexID, uint instance
     uint instance_index = instanceID + cbv_draw_const.start_instance_location;
     InstanceTransform instance = instance_transform_buffer.Load<InstanceTransform>(instance_index * sizeof(InstanceTransform));
 
-    // ByteAddressBuffer instance_material_buffer = ResourceDescriptorHeap[cbv_draw_const.instance_material_buffer_index];
-    // InstanceMaterial material = instance_material_buffer.Load<InstanceMaterial>(instance_index * sizeof(InstanceMaterial));
-    // Texture2D heightmap = ResourceDescriptorHeap[material.heightmap_index];
-    // float height = heightmap.SampleLevel(sam_aniso, vertex.uv, 0).r;
+    ByteAddressBuffer instance_material_buffer = ResourceDescriptorHeap[cbv_draw_const.instance_material_buffer_index];
+    InstanceMaterial material = instance_material_buffer.Load<InstanceMaterial>(instance_index * sizeof(InstanceMaterial));
+    Texture2D heightmap = ResourceDescriptorHeap[material.heightmap_index];
+    float height = heightmap.SampleLevel(sam_aniso, vertex.uv, 0).r;
 
     float3 displaced_position = vertex.position;
-    // displaced_position.y = height * 40.0f;    // TODO: Pass max height to shader
+    displaced_position.y = lerp(0.0f, 200.0f, height);    // TODO: Pass min/max heights to shader
 
     const float4x4 object_to_clip = mul(instance.object_to_world, cbv_frame_const.world_to_clip);
     output.position_vs = mul(float4(displaced_position, 1.0), object_to_clip);
@@ -97,8 +97,9 @@ void psTerrainQuadTree(InstancedVertexOut input, float3 barycentrics : SV_Baryce
 
     // TODO: Pass a flag to the shader to control if we want to 
     // render the wireframe or not
-    color = lerp(float3(0.3, 0.3, 0.3), color, min_bary);
-    min_bary = 1.0;
+    // color = lerp(float3(0.3, 0.3, 0.3), color, min_bary);
+    // min_bary = 1.0;
 
-    out_color = float4(min_bary * color, 1.0);
+    // out_color = float4(min_bary * color, 1.0);
+    out_color = float4(color, 1.0);
 }

--- a/src/shaders/terrain_quad_tree.hlsl
+++ b/src/shaders/terrain_quad_tree.hlsl
@@ -34,8 +34,6 @@ struct InstanceMaterial {
     uint heightmap_index;
 };
 
-// ConstantBuffer<DrawConst> cbv_draw_const : register(b0, per_object_space);
-// ConstantBuffer<FrameConst> cbv_frame_const : register(b0, per_pass_space);
 ConstantBuffer<DrawConst> cbv_draw_const : register(b0);
 ConstantBuffer<FrameConst> cbv_frame_const : register(b1);
 
@@ -87,13 +85,13 @@ void psTerrainQuadTree(InstancedVertexOut input, float3 barycentrics : SV_Baryce
     out_color.a = 1;
  
     // wireframe
-    float3 barys = barycentrics;
-    barys.z = 1.0 - barys.x - barys.y;
-    float3 deltas = fwidth(barys);
-    float3 smoothing = deltas * g_wireframe_smoothing;
-    float3 thickness = deltas * g_wireframe_thickness;
-    barys = smoothstep(thickness, thickness + smoothing, barys);
-    float min_bary = min(barys.x, min(barys.y, barys.z));
+    // float3 barys = barycentrics;
+    // barys.z = 1.0 - barys.x - barys.y;
+    // float3 deltas = fwidth(barys);
+    // float3 smoothing = deltas * g_wireframe_smoothing;
+    // float3 thickness = deltas * g_wireframe_thickness;
+    // barys = smoothstep(thickness, thickness + smoothing, barys);
+    // float min_bary = min(barys.x, min(barys.y, barys.z));
 
     // TODO: Pass a flag to the shader to control if we want to 
     // render the wireframe or not
@@ -101,5 +99,4 @@ void psTerrainQuadTree(InstancedVertexOut input, float3 barycentrics : SV_Baryce
     // min_bary = 1.0;
 
     // out_color = float4(min_bary * color, 1.0);
-    out_color = float4(color, 1.0);
 }

--- a/src/shaders/terrain_quad_tree.hlsl
+++ b/src/shaders/terrain_quad_tree.hlsl
@@ -4,10 +4,11 @@
     "RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED), " \
     "CBV(b0), " \
     "CBV(b1), " \
-    "StaticSampler(s0, filter = FILTER_ANISOTROPIC, maxAnisotropy = 16, visibility = SHADER_VISIBILITY_ALL)"
+    "StaticSampler(s0, filter = FILTER_ANISOTROPIC, maxAnisotropy = 16, visibility = SHADER_VISIBILITY_ALL, addressU = TEXTURE_ADDRESS_CLAMP, addressV = TEXTURE_ADDRESS_CLAMP, addressW = TEXTURE_ADDRESS_CLAMP)"
 
 struct Vertex {
     float3 position;
+    float3 normal;
     float2 uv;
 };
 
@@ -59,13 +60,13 @@ InstancedVertexOut vsTerrainQuadTree(uint vertex_id : SV_VertexID, uint instance
     uint instance_index = instanceID + cbv_draw_const.start_instance_location;
     InstanceTransform instance = instance_transform_buffer.Load<InstanceTransform>(instance_index * sizeof(InstanceTransform));
 
-    ByteAddressBuffer instance_material_buffer = ResourceDescriptorHeap[cbv_draw_const.instance_material_buffer_index];
-    InstanceMaterial material = instance_material_buffer.Load<InstanceMaterial>(instance_index * sizeof(InstanceMaterial));
-    Texture2D heightmap = ResourceDescriptorHeap[material.heightmap_index];
-    float height = heightmap.SampleLevel(sam_aniso, vertex.uv, 0).r;
+    // ByteAddressBuffer instance_material_buffer = ResourceDescriptorHeap[cbv_draw_const.instance_material_buffer_index];
+    // InstanceMaterial material = instance_material_buffer.Load<InstanceMaterial>(instance_index * sizeof(InstanceMaterial));
+    // Texture2D heightmap = ResourceDescriptorHeap[material.heightmap_index];
+    // float height = heightmap.SampleLevel(sam_aniso, vertex.uv, 0).r;
 
     float3 displaced_position = vertex.position;
-    displaced_position.y = height * 247.0f;    // TODO: Pass max height to shader
+    // displaced_position.y = height * 40.0f;    // TODO: Pass max height to shader
 
     const float4x4 object_to_clip = mul(instance.object_to_world, cbv_frame_const.world_to_clip);
     output.position_vs = mul(float4(displaced_position, 1.0), object_to_clip);
@@ -96,7 +97,7 @@ void psTerrainQuadTree(InstancedVertexOut input, float3 barycentrics : SV_Baryce
 
     // TODO: Pass a flag to the shader to control if we want to 
     // render the wireframe or not
-    color = lerp(float3(0.7, 0.7, 0.7), color, min_bary);
+    color = lerp(float3(0.3, 0.3, 0.3), color, min_bary);
     min_bary = 1.0;
 
     out_color = float4(min_bary * color, 1.0);

--- a/src/systems/terrain_quad_tree.zig
+++ b/src/systems/terrain_quad_tree.zig
@@ -1,0 +1,381 @@
+const std = @import("std");
+const L = std.unicode.utf8ToUtf16LeStringLiteral;
+const assert = std.debug.assert;
+const math = std.math;
+
+const glfw = @import("glfw");
+const zm = @import("zmath");
+const zmu = @import("zmathutil");
+const flecs = @import("flecs");
+
+const gfx = @import("../gfx_d3d12.zig");
+const zwin32 = @import("zwin32");
+const d3d12 = zwin32.d3d12;
+
+const fd = @import("../flecs_data.zig");
+const IdLocal = @import("../variant.zig").IdLocal;
+const IndexType = u32;
+
+const FrameUniforms = struct {
+    world_to_clip: zm.Mat,
+    camera_position: [3]f32,
+    time: f32,
+    padding1: u32,
+    padding2: u32,
+    padding3: u32,
+};
+
+const DrawUniforms = struct {
+    start_instance_location: u32,
+    vertex_offset: i32,
+    vertex_buffer_index: u32,
+    instance_transform_buffer_index: u32,
+    instance_material_buffer_index: u32,
+};
+
+const Vertex = struct {
+    position: [3]f32,
+    uv: [2]f32,
+};
+
+const InstanceTransform = struct {
+    object_to_world: zm.Mat,
+};
+
+const InstanceMaterial = struct {
+    basecolor_roughness: [4]f32,
+};
+
+const max_instances = 100;
+const max_instances_per_draw_call = 20;
+
+const DrawCall = struct {
+    mesh_index: u32,
+    index_count: u32,
+    instance_count: u32,
+    index_offset: u32,
+    vertex_offset: i32,
+    start_instance_location: u32,
+};
+
+const Mesh = struct {
+    index_offset: u32,
+    vertex_offset: i32,
+    num_indices: u32,
+    num_vertices: u32,
+};
+
+const SystemState = struct {
+    allocator: std.mem.Allocator,
+    flecs_world: *flecs.World,
+    sys: flecs.EntityId,
+
+    gfx: *gfx.D3D12State,
+
+    query_camera: flecs.Query,
+
+    vertex_buffer: gfx.BufferHandle,
+    index_buffer: gfx.BufferHandle,
+    instance_transform_buffers: [gfx.D3D12State.num_buffered_frames]gfx.BufferHandle,
+    instance_material_buffers: [gfx.D3D12State.num_buffered_frames]gfx.BufferHandle,
+    instance_transforms: std.ArrayList(InstanceTransform),
+    instance_materials: std.ArrayList(InstanceMaterial),
+    draw_calls: std.ArrayList(DrawCall),
+    gpu_frame_profiler_index: u64 = undefined,
+
+    meshes: std.ArrayList(Mesh),
+    camera: struct {
+        position: [3]f32 = .{ 0.0, 4.0, -4.0 },
+        forward: [3]f32 = .{ 0.0, 0.0, 1.0 },
+        pitch: f32 = 0.15 * math.pi,
+        yaw: f32 = 0.0,
+    } = .{},
+};
+
+fn initScene(
+    _: std.mem.Allocator,
+    meshes: *std.ArrayList(Mesh),
+    meshes_indices: *std.ArrayList(IndexType),
+    meshes_vertices: *std.ArrayList(Vertex),
+) !void {
+    // Load the LOD5 obj
+    var file = std.fs.cwd().openFile("content/meshes/LOD5.obj", .{}) catch |err| {
+        std.log.warn("Unable to open file: {s}", .{@errorName(err)});
+        return err;
+    };
+    defer file.close();
+
+    var buffer_reader = std.io.bufferedReader(file.reader());
+    var in_stream = buffer_reader.reader();
+
+    var mesh = Mesh{
+        .index_offset = @intCast(u32, meshes_indices.items.len),
+        .vertex_offset = @intCast(i32, meshes_vertices.items.len),
+        .num_indices = 0,
+        .num_vertices = 0,
+    };
+
+    var buf: [1024]u8 = undefined;
+    var vertex_offset = meshes_vertices.items.len;
+
+    while (try in_stream.readUntilDelimiterOrEof(&buf, '\n')) |line| {
+        var it = std.mem.split(u8, line, " ");
+
+        var first = it.first();
+        if (std.mem.eql(u8, first, "v")) {
+            var vertex: Vertex = undefined;
+            vertex.position[0] = std.fmt.parseFloat(f32, it.next().?) catch unreachable;
+            vertex.position[1] = std.fmt.parseFloat(f32, it.next().?) catch unreachable;
+            vertex.position[2] = std.fmt.parseFloat(f32, it.next().?) catch unreachable;
+            meshes_vertices.append(vertex) catch unreachable;
+        } else if (std.mem.eql(u8, first, "vt")) { // NOTE: This only works with this mesh. We need to fix this
+            var vertex = &meshes_vertices.items[vertex_offset];
+            vertex.uv[0] = std.fmt.parseFloat(f32, it.next().?) catch unreachable;
+            vertex.uv[1] = std.fmt.parseFloat(f32, it.next().?) catch unreachable;
+            vertex_offset += 1;
+        } else if (std.mem.eql(u8, first, "f")) {
+            var triangle_index: u32 = 0;
+            while (triangle_index < 3) : (triangle_index += 1) {
+                var triangles_iterator = std.mem.split(u8, it.next().?, "/");
+
+                // NOTE: we're assuming position and uvs are aligned
+                var index = std.fmt.parseInt(IndexType, triangles_iterator.next().?, 10) catch unreachable;
+                index -= 1;
+                meshes_indices.append(index) catch unreachable;
+            }
+        }
+    }
+
+    assert(vertex_offset == meshes_vertices.items.len);
+    mesh.num_indices = @intCast(u32, meshes_indices.items.len);
+    mesh.num_vertices = @intCast(u32, meshes_vertices.items.len);
+    meshes.append(mesh) catch unreachable;
+}
+
+pub fn create(name: IdLocal, allocator: std.mem.Allocator, gfxstate: *gfx.D3D12State, flecs_world: *flecs.World) !*SystemState {
+    // Queries
+    var query_builder_camera = flecs.QueryBuilder.init(flecs_world.*);
+    _ = query_builder_camera
+        .withReadonly(fd.Camera)
+        .withReadonly(fd.Transform);
+    var query_camera = query_builder_camera.buildQuery();
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var meshes = std.ArrayList(Mesh).init(allocator);
+    var meshes_indices = std.ArrayList(IndexType).init(arena);
+    var meshes_vertices = std.ArrayList(Vertex).init(arena);
+    initScene(allocator, &meshes, &meshes_indices, &meshes_vertices) catch unreachable;
+
+    const total_num_vertices = @intCast(u32, meshes_vertices.items.len);
+    const total_num_indices = @intCast(u32, meshes_indices.items.len);
+
+    // Create a vertex buffer.
+    var vertex_buffer = gfxstate.createBuffer(.{
+        .size = total_num_vertices * @sizeOf(Vertex),
+        .state = d3d12.RESOURCE_STATES.GENERIC_READ,
+        .name = L("Terrain Quad Tree Vertex Buffer"),
+        .persistent = true,
+        .has_cbv = false,
+        .has_srv = true,
+        .has_uav = false,
+    }) catch unreachable;
+
+    // Create an index buffer.
+    var index_buffer = gfxstate.createBuffer(.{
+        .size = total_num_indices * @sizeOf(IndexType),
+        .state = .{ .INDEX_BUFFER = true },
+        .name = L("Terrain Quad Tree Index Buffer"),
+        .persistent = false,
+        .has_cbv = false,
+        .has_srv = false,
+        .has_uav = false,
+    }) catch unreachable;
+
+    // Create instance buffers.
+    const instance_transform_buffers = blk: {
+        var buffers: [gfx.D3D12State.num_buffered_frames]gfx.BufferHandle = undefined;
+        for (buffers) |_, buffer_index| {
+            const bufferDesc = gfx.BufferDesc{
+                .size = max_instances * @sizeOf(InstanceTransform),
+                .state = d3d12.RESOURCE_STATES.GENERIC_READ,
+                .name = L("Terrain Quad Tree Instance Transform Buffer"),
+                .persistent = true,
+                .has_cbv = false,
+                .has_srv = true,
+                .has_uav = false,
+            };
+
+            buffers[buffer_index] = gfxstate.createBuffer(bufferDesc) catch unreachable;
+        }
+
+        break :blk buffers;
+    };
+
+    const instance_material_buffers = blk: {
+        var buffers: [gfx.D3D12State.num_buffered_frames]gfx.BufferHandle = undefined;
+        for (buffers) |_, buffer_index| {
+            const bufferDesc = gfx.BufferDesc{
+                .size = max_instances * @sizeOf(InstanceMaterial),
+                .state = d3d12.RESOURCE_STATES.GENERIC_READ,
+                .name = L("Terrain Quad Tree Instance Material Buffer"),
+                .persistent = true,
+                .has_cbv = false,
+                .has_srv = true,
+                .has_uav = false,
+            };
+
+            buffers[buffer_index] = gfxstate.createBuffer(bufferDesc) catch unreachable;
+        }
+
+        break :blk buffers;
+    };
+
+    var draw_calls = std.ArrayList(DrawCall).init(allocator);
+    var instance_transforms = std.ArrayList(InstanceTransform).init(allocator);
+    var instance_materials = std.ArrayList(InstanceMaterial).init(allocator);
+
+    gfxstate.scheduleUploadDataToBuffer(Vertex, vertex_buffer, 0, meshes_vertices.items);
+    gfxstate.scheduleUploadDataToBuffer(IndexType, index_buffer, 0, meshes_indices.items);
+
+    var state = allocator.create(SystemState) catch unreachable;
+    var sys = flecs_world.newWrappedRunSystem(name.toCString(), .on_update, fd.NOCOMP, update, .{ .ctx = state });
+
+    state.* = .{
+        .allocator = allocator,
+        .flecs_world = flecs_world,
+        .sys = sys,
+        .gfx = gfxstate,
+        .vertex_buffer = vertex_buffer,
+        .index_buffer = index_buffer,
+        .instance_transform_buffers = instance_transform_buffers,
+        .instance_material_buffers = instance_material_buffers,
+        .draw_calls = draw_calls,
+        .instance_transforms = instance_transforms,
+        .instance_materials = instance_materials,
+        .meshes = meshes,
+        .query_camera = query_camera,
+    };
+
+    return state;
+}
+
+pub fn destroy(state: *SystemState) void {
+    state.query_camera.deinit();
+    state.meshes.deinit();
+    state.instance_transforms.deinit();
+    state.instance_materials.deinit();
+    state.draw_calls.deinit();
+    state.allocator.destroy(state);
+}
+
+// ██╗   ██╗██████╗ ██████╗  █████╗ ████████╗███████╗
+// ██║   ██║██╔══██╗██╔══██╗██╔══██╗╚══██╔══╝██╔════╝
+// ██║   ██║██████╔╝██║  ██║███████║   ██║   █████╗
+// ██║   ██║██╔═══╝ ██║  ██║██╔══██║   ██║   ██╔══╝
+// ╚██████╔╝██║     ██████╔╝██║  ██║   ██║   ███████╗
+//  ╚═════╝ ╚═╝     ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚══════╝
+
+fn update(iter: *flecs.Iterator(fd.NOCOMP)) void {
+    var state = @ptrCast(*SystemState, @alignCast(@alignOf(SystemState), iter.iter.ctx));
+
+    const CameraQueryComps = struct {
+        cam: *const fd.Camera,
+        transform: *const fd.Transform,
+    };
+    var camera_comps: ?CameraQueryComps = blk: {
+        var entity_iter_camera = state.query_camera.iterator(CameraQueryComps);
+        while (entity_iter_camera.next()) |comps| {
+            if (comps.cam.active) {
+                break :blk comps;
+            }
+        }
+
+        break :blk null;
+    };
+
+    if (camera_comps == null) {
+        return;
+    }
+
+    const cam = camera_comps.?.cam;
+    const cam_world_to_clip = zm.loadMat(cam.world_to_clip[0..]);
+    state.gpu_frame_profiler_index = state.gfx.gpu_profiler.startProfile(state.gfx.gctx.cmdlist, "Terrain Quad Tree");
+
+    const pipeline_info = state.gfx.getPipeline(IdLocal.init("terrain_quad_tree"));
+    state.gfx.gctx.setCurrentPipeline(pipeline_info.?.pipeline_handle);
+
+    state.gfx.gctx.cmdlist.IASetPrimitiveTopology(.TRIANGLELIST);
+    const index_buffer = state.gfx.lookupBuffer(state.index_buffer);
+    const index_buffer_resource = state.gfx.gctx.lookupResource(index_buffer.?.resource);
+    state.gfx.gctx.cmdlist.IASetIndexBuffer(&.{
+        .BufferLocation = index_buffer_resource.?.GetGPUVirtualAddress(),
+        .SizeInBytes = @intCast(c_uint, index_buffer_resource.?.GetDesc().Width),
+        .Format = if (@sizeOf(IndexType) == 2) .R16_UINT else .R32_UINT,
+    });
+
+    // Upload per-frame constant data.
+    const camera_position = camera_comps.?.transform.getPos00();
+    {
+        const environment_info = state.flecs_world.getSingletonMut(fd.EnvironmentInfo).?;
+        const world_time = environment_info.world_time;
+        const mem = state.gfx.gctx.allocateUploadMemory(FrameUniforms, 1);
+        mem.cpu_slice[0].world_to_clip = zm.transpose(cam_world_to_clip);
+        mem.cpu_slice[0].camera_position = camera_position;
+        mem.cpu_slice[0].time = world_time;
+
+        state.gfx.gctx.cmdlist.SetGraphicsRootConstantBufferView(1, mem.gpu_base);
+    }
+
+    // Reset transforms, materials and draw calls array list
+    state.instance_transforms.clearRetainingCapacity();
+    state.instance_materials.clearRetainingCapacity();
+    state.draw_calls.clearRetainingCapacity();
+
+    // Test single instance
+    {
+        const mesh = state.meshes.items[0];
+        state.draw_calls.append(.{
+            .mesh_index = 0,
+            .index_count = mesh.num_indices,
+            .instance_count = 1,
+            .index_offset = mesh.index_offset,
+            .vertex_offset = mesh.vertex_offset,
+            .start_instance_location = 0,
+        }) catch unreachable;
+
+        const object_to_world = zm.translation(0.0, 50.0, 0.0);
+        state.instance_transforms.append(.{ .object_to_world = zm.transpose(object_to_world) }) catch unreachable;
+        state.instance_materials.append(.{ .basecolor_roughness = [4]f32{ 0.2, 0.8, 0.4, 0.5, } }) catch unreachable;
+    }
+
+    const frame_index = state.gfx.gctx.frame_index;
+    state.gfx.uploadDataToBuffer(InstanceTransform, state.instance_transform_buffers[frame_index], 0, state.instance_transforms.items);
+    state.gfx.uploadDataToBuffer(InstanceMaterial, state.instance_material_buffers[frame_index], 0, state.instance_materials.items);
+
+    const vertex_buffer = state.gfx.lookupBuffer(state.vertex_buffer);
+    const instance_transform_buffer = state.gfx.lookupBuffer(state.instance_transform_buffers[frame_index]);
+    const instance_material_buffer = state.gfx.lookupBuffer(state.instance_material_buffers[frame_index]);
+
+    for (state.draw_calls.items) |draw_call| {
+        const mem = state.gfx.gctx.allocateUploadMemory(DrawUniforms, 1);
+        mem.cpu_slice[0].start_instance_location = draw_call.start_instance_location;
+        mem.cpu_slice[0].vertex_offset = draw_call.vertex_offset;
+        mem.cpu_slice[0].vertex_buffer_index = vertex_buffer.?.persistent_descriptor.index;
+        mem.cpu_slice[0].instance_transform_buffer_index = instance_transform_buffer.?.persistent_descriptor.index;
+        mem.cpu_slice[0].instance_material_buffer_index = instance_material_buffer.?.persistent_descriptor.index;
+        state.gfx.gctx.cmdlist.SetGraphicsRootConstantBufferView(0, mem.gpu_base);
+
+        state.gfx.gctx.cmdlist.DrawIndexedInstanced(
+            draw_call.index_count,
+            draw_call.instance_count,
+            draw_call.index_offset,
+            draw_call.vertex_offset,
+            draw_call.start_instance_location,
+        );
+    }
+
+    state.gfx.gpu_profiler.endProfile(state.gfx.gctx.cmdlist, state.gpu_frame_profiler_index, state.gfx.gctx.frame_index);
+}

--- a/src/systems/terrain_quad_tree.zig
+++ b/src/systems/terrain_quad_tree.zig
@@ -306,7 +306,6 @@ fn divideQuadTreeNode(
         var center_x = if (child_index % 2 == 0) node.center[0] - node.size[0] * 0.5 else node.center[0] + node.size[0] * 0.5;
         var center_y = if (child_index < 2) node.center[1] - node.size[1] * 0.5 else node.center[1] + node.size[1] * 0.5;
         var patch_index_x: u32 = if (child_index % 2 == 0) 0 else 1;
-        // var patch_index_y: u32 = if (child_index < 2) 0 else 1;
         var patch_index_y: u32 = if (child_index < 2) 1 else 0;
 
         var child_node = QuadTreeNode{
@@ -314,7 +313,7 @@ fn divideQuadTreeNode(
             .size = [2]f32{ node.size[0] * 0.5, node.size[1] * 0.5 },
             .child_indices = [4]u32{ invalid_index, invalid_index, invalid_index, invalid_index },
             .mesh_lod = node.mesh_lod - 1,
-            .patch_index = [2]u32{ node.patch_index[0] + patch_index_x, node.patch_index[1] + patch_index_y },
+            .patch_index = [2]u32{ node.patch_index[0] * 2 + patch_index_x, node.patch_index[1] * 2 + patch_index_y },
             .heightmap_handle = undefined,
         };
 

--- a/sync_external.py
+++ b/sync_external.py
@@ -20,7 +20,7 @@ def sync_lib(folder, git_path, commit_sha):
 os.chdir("external")
 sync_lib("zig-args", "https://github.com/MasterQ32/zig-args.git", "77a2c6557bb9768dc332f98cc6cbc9eac94c93aa")
 # sync_lib("zig-flecs", "https://github.com/prime31/zig-flecs.git")
-sync_lib("zig-gamedev", "https://github.com/Srekel/zig-gamedev.git", "b9b5bead8a24988a2dafb623f9bcd6f3284a0d62")
+sync_lib("zig-gamedev", "https://github.com/Srekel/zig-gamedev.git", "38ec3e469afd9b882a59da3edb67a1f0f27b47b5")
 sync_lib("zig-flecs", "https://github.com/Srekel/zig-flecs.git", "8cbf441c7d508f11da40ff80ec72df94c36920e1")
 sync_lib("zigimg", "https://github.com/zigimg/zigimg.git", "5e8e5687ce1edd7dd1040c0580ec0731bcfbd793")
 # sync_lib("zls", "https://github.com/zigtools/zls.git", "949e4fe525abaf25699b7f15368ecdc49fd8b786")


### PR DESCRIPTION
This PR implements a new terrain system based on the `Terrain Rendering: Far Cry 5` GDC presentation.

The new terrain system is not hooked to `game.zig` yet and 2 of its subsystems (meshes and textures) need to be extracted and made more general-purpouse for the rest of the game.

The new Terrain Quad Tree depends on some OBJ files that I have not committed to git.