### PR TITLE
Left Handed coordinate system

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -453,14 +453,14 @@ pub fn run() void {
     const bow_ent = flecs_world.newEntity();
     bow_ent.setName("bow");
     bow_ent.set(fd.Position{ .x = 0.25, .y = 0, .z = 1 });
-    bow_ent.set(fd.EulerRotation{ .yaw = std.math.pi * -0.5 });
+    bow_ent.set(fd.EulerRotation{});
     bow_ent.set(fd.Scale.createScalar(1));
     bow_ent.set(fd.Transform{});
     bow_ent.set(fd.Forward{});
     bow_ent.set(fd.Dynamic{});
     bow_ent.set(fd.CIShapeMeshInstance{
         .id = IdLocal.id64("bow"),
-        .basecolor_roughness = .{ .r = 0.6, .g = 0.4, .b = 0.1, .roughness = 1.0 },
+        .basecolor_roughness = .{ .r = 1.0, .g = 1.0, .b = 1.0, .roughness = 1.0 },
     });
 
     // ██████╗ ██╗      █████╗ ██╗   ██╗███████╗██████╗

--- a/src/shaders/terrain_quad_tree.hlsl
+++ b/src/shaders/terrain_quad_tree.hlsl
@@ -77,8 +77,7 @@ InstancedVertexOut vsTerrainQuadTree(uint vertex_id : SV_VertexID, uint instance
     InstanceData instance = instance_data_buffer.Load<InstanceData>(instance_index * sizeof(InstanceData));
 
     Texture2D heightmap = ResourceDescriptorHeap[instance.heightmap_index];
-    // float2 uv = float2(vertex.uv.x, 1.0 - vertex.uv.y);
-    float2 uv = float2(vertex.uv.x, vertex.uv.y);
+    float2 uv = float2(vertex.uv.x, 1.0 - vertex.uv.y);
     float height = heightmap.SampleLevel(sam_linear_clamp, uv, 0).r;// * 2.0 - 1.0;
 
     float3 displaced_position = vertex.position;


### PR DESCRIPTION
This PR fixes the OBJ importer so that it produces DirectX-compatible meshes.

To do so we need to flip the UV's and the triangle winding order, and convert all the vertices attributes (position, normal, tangent) to a Left Hand coordinate system.

I've also removed the 90deg rotation to the bow entity transform since I've re-exported bow and arrow with the correct forward orientation (Y+ in Blender)