### PR TITLE
Add support for rendering sub-meshes

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -66,6 +66,7 @@ pub const input_gamepad_move_y = IdLocal.init("input_gamepad_move_y");
 pub const input_look_yaw = IdLocal.init("look_yaw");
 pub const input_look_pitch = IdLocal.init("look_pitch");
 
+pub const input_draw_bounding_spheres = IdLocal.init("draw_bounding_spheres");
 pub const input_camera_switch = IdLocal.init("camera_switch");
 pub const input_camera_freeze_rendering = IdLocal.init("camera_freeze_rendering");
 pub const input_exit = IdLocal.init("exit");

--- a/src/flecs_data.zig
+++ b/src/flecs_data.zig
@@ -10,6 +10,7 @@ const IdLocal = @import("variant.zig").IdLocal;
 const MeshHandle = @import("gfx_d3d12.zig").MeshHandle;
 const TextureHandle = @import("gfx_d3d12.zig").TextureHandle;
 const MaterialHandle = @import("gfx_d3d12.zig").MaterialHandle;
+const rt = @import("renderer/renderer_types.zig");
 
 pub fn registerComponents(ecsu_world: ecsu.World) void {
     var ecs_world = ecsu_world.world;
@@ -374,7 +375,9 @@ pub const StaticMesh = struct {
 
 pub const StaticMeshComponent = struct {
     mesh_handle: MeshHandle,
-    material_handle: MaterialHandle,
+
+    material_count: u32,
+    material_handles: [rt.sub_mesh_count_max]MaterialHandle,
 };
 
 //  ██████╗ █████╗ ███╗   ███╗███████╗██████╗  █████╗

--- a/src/game.zig
+++ b/src/game.zig
@@ -178,6 +178,7 @@ pub fn run() void {
         itm.putAssumeCapacity(config.input_gamepad_move_y, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_look_yaw, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_look_pitch, input.TargetValue{ .number = 0 });
+        itm.putAssumeCapacity(config.input_draw_bounding_spheres, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_camera_switch, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_camera_freeze_rendering, input.TargetValue{ .number = 0 });
         itm.putAssumeCapacity(config.input_exit, input.TargetValue{ .number = 0 });
@@ -205,6 +206,7 @@ pub fn run() void {
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_interact, .source = input.BindingSource{ .keyboard_key = .f } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_wielded_use_primary, .source = input.BindingSource{ .keyboard_key = .g } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_wielded_use_secondary, .source = input.BindingSource{ .keyboard_key = .h } });
+        keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_draw_bounding_spheres, .source = input.BindingSource{ .keyboard_key = .b } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_camera_switch, .source = input.BindingSource{ .keyboard_key = .tab } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_camera_freeze_rendering, .source = input.BindingSource{ .keyboard_key = .r } });
         keyboard_map.bindings.appendAssumeCapacity(.{ .target_id = config.input_exit, .source = input.BindingSource{ .keyboard_key = .escape } });
@@ -532,9 +534,7 @@ pub fn run() void {
 
     const sun_light = ecsu_world.newEntity();
     sun_light.set(fd.Rotation.initFromEulerDegrees(50.0, -30.0, 0.0));
-    sun_light.set(fd.DirectionalLight{
-        .radiance = .{ .r = 2.5, .g = 2.5, .b = 2.5 }
-    });
+    sun_light.set(fd.DirectionalLight{ .radiance = .{ .r = 2.5, .g = 2.5, .b = 2.5 } });
 
     const player_spawn = blk: {
         var builder = ecsu.QueryBuilder.init(ecsu_world);

--- a/src/game.zig
+++ b/src/game.zig
@@ -53,6 +53,7 @@ const SpawnContext = struct {
 
 var giant_ant_prefab: ecsu.Entity = undefined;
 var bow_prefab: ecsu.Entity = undefined;
+var medium_house_prefab: ecsu.Entity = undefined;
 
 fn spawnGiantAnt(entity: ecs.entity_t, data: *anyopaque) void {
     _ = entity;
@@ -145,6 +146,7 @@ pub fn run() void {
     defer zmesh.deinit();
 
     // TODO(gmodarelli): Add a function to destroy the prefab's GPU resources
+    medium_house_prefab = prefab_manager.loadPrefabFromGLTF("content/prefabs/buildings/medium_house/medium_house.gltf", &ecsu_world, &gfx_state, std.heap.page_allocator) catch unreachable;
     giant_ant_prefab = prefab_manager.loadPrefabFromGLTF("content/prefabs/creatures/giant_ant/giant_ant.gltf", &ecsu_world, &gfx_state, std.heap.page_allocator) catch unreachable;
     bow_prefab = prefab_manager.loadPrefabFromGLTF("content/prefabs/props/bow_arrow/bow.gltf", &ecsu_world, &gfx_state, std.heap.page_allocator) catch unreachable;
     _ = prefab_manager.loadPrefabFromGLTF("content/prefabs/props/bow_arrow/arrow.gltf", &ecsu_world, &gfx_state, std.heap.page_allocator) catch unreachable;

--- a/src/game.zig
+++ b/src/game.zig
@@ -424,6 +424,7 @@ pub fn run() void {
         std.heap.page_allocator,
         ecsu_world,
         world_patch_mgr,
+        &prefab_manager,
     );
     defer patch_prop_system.destroy(patch_prop_sys);
 

--- a/src/gfx_d3d12.zig
+++ b/src/gfx_d3d12.zig
@@ -591,20 +591,24 @@ pub const D3D12State = struct {
 
         // 1. Update sub meshes' lods vertex and index offsets
         for (0..mesh.sub_mesh_count) |sub_mesh_index| {
+            const sub_mesh = &mesh.sub_meshes[sub_mesh_index];
+            const bounding_box = sub_mesh.bounding_box;
+
             new_mesh.sub_meshes[sub_mesh_index] = SubMesh{
-                .lod_count = mesh.sub_meshes[sub_mesh_index].lod_count,
+                .lod_count = sub_mesh.lod_count,
                 .lods = undefined,
                 .bounding_box = .{
-                    .min = [3]f32{ mesh.sub_meshes[sub_mesh_index].bounding_box.min[0], mesh.sub_meshes[sub_mesh_index].bounding_box.min[1], mesh.sub_meshes[sub_mesh_index].bounding_box.min[2] },
-                    .max = [3]f32{ mesh.sub_meshes[sub_mesh_index].bounding_box.max[0], mesh.sub_meshes[sub_mesh_index].bounding_box.max[1], mesh.sub_meshes[sub_mesh_index].bounding_box.max[2] },
+                    .min = [3]f32{ bounding_box.min[0], bounding_box.min[1], bounding_box.min[2] },
+                    .max = [3]f32{ bounding_box.max[0], bounding_box.max[1], bounding_box.max[2] },
                 },
             };
 
-            for (0..new_mesh.sub_meshes[sub_mesh_index].lod_count) |i| {
-                new_mesh.sub_meshes[sub_mesh_index].lods[i].vertex_offset = mesh.sub_meshes[sub_mesh_index].lods[i].vertex_offset;
-                new_mesh.sub_meshes[sub_mesh_index].lods[i].index_offset = mesh.sub_meshes[sub_mesh_index].lods[i].index_offset;
-                new_mesh.sub_meshes[sub_mesh_index].lods[i].vertex_count = mesh.sub_meshes[sub_mesh_index].lods[i].vertex_count;
-                new_mesh.sub_meshes[sub_mesh_index].lods[i].index_count = mesh.sub_meshes[sub_mesh_index].lods[i].index_count;
+            var new_submesh = &new_mesh.sub_meshes[sub_mesh_index];
+            for (0..new_submesh.lod_count) |i| {
+                new_submesh.lods[i].vertex_offset = sub_mesh.lods[i].vertex_offset;
+                new_submesh.lods[i].index_offset = sub_mesh.lods[i].index_offset;
+                new_submesh.lods[i].vertex_count = sub_mesh.lods[i].vertex_count;
+                new_submesh.lods[i].index_count = sub_mesh.lods[i].index_count;
             }
         }
 

--- a/src/gfx_d3d12.zig
+++ b/src/gfx_d3d12.zig
@@ -608,6 +608,9 @@ pub const D3D12State = struct {
             }
         }
 
+        new_mesh.bounding_box.min = [3]f32{ mesh.bounding_box.min[0], mesh.bounding_box.min[1], mesh.bounding_box.min[2] };
+        new_mesh.bounding_box.max = [3]f32{ mesh.bounding_box.max[0], mesh.bounding_box.max[1], mesh.bounding_box.max[2] };
+
         // 2. Upload vertex data to the vertex buffer
         _ = self.scheduleUploadDataToBuffer(Vertex, vertex_buffer, 0, vertices);
 

--- a/src/offline_generation/graph/city.zig
+++ b/src/offline_generation/graph/city.zig
@@ -381,7 +381,7 @@ pub fn funcTemplateCity(node: *g.Node, output: *g.NodeOutput, context: *g.GraphC
                     var city_x: f32 = 0;
                     while (city_x < CITY_HEIGHT_TEST_SKIP) : (city_x += stride_f) {
                         pixels_index = @as(u64, //
-                        @intFromFloat(@divFloor(pos[0] + city_x, stride_f) + //
+                            @intFromFloat(@divFloor(pos[0] + city_x, stride_f) + //
                             @divFloor((pos[2] + city_z) * image_width, stride_f)));
                         // pixels_index = @intCast(u64, @divFloor(pos[0], stride) + @divFloor((pos[2] + 0) * image_width, stride));
                         // const height = patches.getHeight(pos[0],pos[2]);

--- a/src/prefab_manager.zig
+++ b/src/prefab_manager.zig
@@ -187,7 +187,6 @@ pub const PrefabManager = struct {
         }
     }
 
-
     fn parsePrimitiveMaterial(
         _: *@This(),
         primitive: *const zcgltf.Primitive,

--- a/src/renderer/mesh_loader.zig
+++ b/src/renderer/mesh_loader.zig
@@ -13,8 +13,8 @@ pub fn parseMeshPrimitive(
     meshes_vertices: *std.ArrayList(rt.Vertex),
     arena: std.mem.Allocator,
 ) !rt.SubMesh {
-    const num_vertices: u32 = @as(u32, @intCast(primitive.attributes[0].data.count));
-    const num_indices: u32 = @as(u32, @intCast(primitive.indices.?.count));
+    const num_vertices: u32 = @intCast(primitive.attributes[0].data.count);
+    const num_indices: u32 = @intCast(primitive.indices.?.count);
 
     var indices = std.ArrayList(rt.IndexType).init(arena);
     var positions = std.ArrayList([3]f32).init(arena);
@@ -133,10 +133,10 @@ pub fn parseMeshPrimitive(
     };
 
     sub_mesh.lods[0] = .{
-        .index_offset = @as(u32, @intCast(meshes_indices.items.len)),
-        .index_count = @as(u32, @intCast(indices.items.len)),
-        .vertex_offset = @as(u32, @intCast(meshes_vertices.items.len)),
-        .vertex_count = @as(u32, @intCast(positions.items.len)),
+        .index_offset = @intCast(meshes_indices.items.len),
+        .index_count = @intCast(indices.items.len),
+        .vertex_offset = @intCast(meshes_vertices.items.len),
+        .vertex_count = @intCast(positions.items.len),
     };
 
     try meshes_vertices.ensureTotalCapacity(meshes_vertices.items.len + positions.items.len);
@@ -219,9 +219,9 @@ pub fn loadObjMeshFromFile(
                 indices.clearRetainingCapacity();
                 vertices.clearRetainingCapacity();
 
-                previous_obj_positions_count += @as(u32, @intCast(positions.items.len));
-                previous_obj_uvs_count += @as(u32, @intCast(uvs.items.len));
-                previous_obj_normals_count += @as(u32, @intCast(normals.items.len));
+                previous_obj_positions_count += @intCast(positions.items.len);
+                previous_obj_uvs_count += @intCast(uvs.items.len);
+                previous_obj_normals_count += @intCast(normals.items.len);
 
                 positions.clearRetainingCapacity();
                 colors.clearRetainingCapacity();
@@ -236,9 +236,9 @@ pub fn loadObjMeshFromFile(
                 indices.clearRetainingCapacity();
                 vertices.clearRetainingCapacity();
 
-                previous_obj_positions_count += @as(u32, @intCast(positions.items.len));
-                previous_obj_uvs_count += @as(u32, @intCast(uvs.items.len));
-                previous_obj_normals_count += @as(u32, @intCast(normals.items.len));
+                previous_obj_positions_count += @intCast(positions.items.len);
+                previous_obj_uvs_count += @intCast(uvs.items.len);
+                previous_obj_normals_count += @intCast(normals.items.len);
 
                 positions.clearRetainingCapacity();
                 colors.clearRetainingCapacity();
@@ -288,7 +288,7 @@ pub fn loadObjMeshFromFile(
                 normal_index -= previous_obj_normals_count;
                 normal_index -= 1;
 
-                const unique_vertex_index = @as(u32, @intCast(vertices.items.len));
+                const unique_vertex_index: u32 = @intCast(vertices.items.len);
                 try indices.append(unique_vertex_index);
                 try vertices.append(.{
                     .position = positions.items[position_index],
@@ -458,10 +458,10 @@ fn storeMeshLod(
     );
 
     sub_mesh.lods[sub_mesh.lod_count] = .{
-        .index_offset = @as(u32, @intCast(meshes_indices.items.len)),
-        .index_count = @as(u32, @intCast(remapped_indices.items.len)),
-        .vertex_offset = @as(u32, @intCast(meshes_vertices.items.len)),
-        .vertex_count = @as(u32, @intCast(optimized_vertices.items.len)),
+        .index_offset = @intCast(meshes_indices.items.len),
+        .index_count = @intCast(remapped_indices.items.len),
+        .vertex_offset = @intCast(meshes_vertices.items.len),
+        .vertex_count = @intCast(optimized_vertices.items.len),
     };
 
     sub_mesh.lod_count += 1;

--- a/src/renderer/mesh_loader.zig
+++ b/src/renderer/mesh_loader.zig
@@ -12,7 +12,7 @@ pub fn parseMeshPrimitive(
     meshes_indices: *std.ArrayList(rt.IndexType),
     meshes_vertices: *std.ArrayList(rt.Vertex),
     arena: std.mem.Allocator,
-) !rt.Mesh {
+) !rt.SubMesh {
     const num_vertices: u32 = @as(u32, @intCast(primitive.attributes[0].data.count));
     const num_indices: u32 = @as(u32, @intCast(primitive.indices.?.count));
 
@@ -123,11 +123,8 @@ pub fn parseMeshPrimitive(
         max[2] = @max(max[2], position[2]);
     }
 
-    // TODO(gmodarelli): use a different Mesh struct here since we're not interested in vertex and index buffers
-    var mesh = rt.Mesh{
-        .vertex_buffer = undefined,
-        .index_buffer = undefined,
-        .num_lods = 1,
+    var sub_mesh = rt.SubMesh{
+        .lod_count = 1,
         .lods = undefined,
         .bounding_box = .{
             .min = min,
@@ -135,7 +132,7 @@ pub fn parseMeshPrimitive(
         },
     };
 
-    mesh.lods[0] = .{
+    sub_mesh.lods[0] = .{
         .index_offset = @as(u32, @intCast(meshes_indices.items.len)),
         .index_count = @as(u32, @intCast(indices.items.len)),
         .vertex_offset = @as(u32, @intCast(meshes_vertices.items.len)),
@@ -155,7 +152,7 @@ pub fn parseMeshPrimitive(
     }
 
     meshes_indices.appendSlice(indices.items) catch unreachable;
-    return mesh;
+    return sub_mesh;
 }
 
 
@@ -192,14 +189,18 @@ pub fn loadObjMeshFromFile(
     var previous_obj_uvs_count: u32 = 0;
     var previous_obj_normals_count: u32 = 0;
 
-    // TODO(gmodarelli): use a different Mesh struct here since we're not interested in vertex and index buffers
     var mesh = rt.Mesh{
         .vertex_buffer = undefined,
         .index_buffer = undefined,
-        .num_lods = 0,
-        .lods = undefined,
+        .sub_mesh_count = 1,
+        .sub_meshes = undefined,
         .bounding_box = undefined,
     };
+
+    var sub_mesh = &mesh.sub_meshes[0];
+    sub_mesh.lod_count = 0;
+    sub_mesh.lods = undefined;
+    sub_mesh.bounding_box = undefined;
 
     while (try in_stream.readUntilDelimiterOrEof(&buf, '\n')) |line| {
         var it = std.mem.split(u8, line, " ");
@@ -213,7 +214,7 @@ pub fn loadObjMeshFromFile(
                     &vertices,
                     meshes_indices,
                     meshes_vertices,
-                    &mesh,
+                    sub_mesh,
                 );
 
                 indices.clearRetainingCapacity();
@@ -308,11 +309,35 @@ pub fn loadObjMeshFromFile(
             &vertices,
             meshes_indices,
             meshes_vertices,
-            &mesh,
+            sub_mesh,
         );
 
         inside_object = false;
     }
+
+
+    // Update mesh bounding box (encapsulates all sub-meshes bounding boxes)
+    var min = [3]f32{ std.math.floatMax(f32), std.math.floatMax(f32), std.math.floatMax(f32) };
+    var max = [3]f32{ std.math.floatMin(f32), std.math.floatMin(f32), std.math.floatMin(f32) };
+
+    std.log.debug("Mesh: {s}", .{path});
+    for (0..mesh.sub_mesh_count) |i| {
+        std.log.debug("Sub Mesh {d} - Min ({d:.3}, {d:.3}, {d:.3}) - Max ({d:.3}, {d:.3}, {d:.3})", .{i, mesh.sub_meshes[i].bounding_box.min[0], mesh.sub_meshes[i].bounding_box.min[1], mesh.sub_meshes[i].bounding_box.min[2], mesh.sub_meshes[i].bounding_box.max[0], mesh.sub_meshes[i].bounding_box.max[1], mesh.sub_meshes[i].bounding_box.max[2]});
+
+        min[0] = @min(min[0], mesh.sub_meshes[i].bounding_box.min[0]);
+        min[1] = @min(min[1], mesh.sub_meshes[i].bounding_box.min[1]);
+        min[2] = @min(min[2], mesh.sub_meshes[i].bounding_box.min[2]);
+
+        max[0] = @max(max[0], mesh.sub_meshes[i].bounding_box.max[0]);
+        max[1] = @max(max[1], mesh.sub_meshes[i].bounding_box.max[1]);
+        max[2] = @max(max[2], mesh.sub_meshes[i].bounding_box.max[2]);
+    }
+
+    mesh.bounding_box = .{
+        .min = min,
+        .max = max,
+    };
+    std.log.debug("Mesh - Min ({d:.3}, {d:.3}, {d:.3}) - Max ({d:.3}, {d:.3}, {d:.3})\n", .{mesh.bounding_box.min[0], mesh.bounding_box.min[1], mesh.bounding_box.min[2], mesh.bounding_box.max[0], mesh.bounding_box.max[1], mesh.bounding_box.max[2]});
 
     return mesh;
 }
@@ -323,7 +348,7 @@ fn storeMeshLod(
     vertices: *std.ArrayList(rt.Vertex),
     meshes_indices: *std.ArrayList(rt.IndexType),
     meshes_vertices: *std.ArrayList(rt.Vertex),
-    mesh: *rt.Mesh,
+    sub_mesh: *rt.SubMesh,
 ) !void {
     // Calculate tangents for every vertex
     {
@@ -438,14 +463,14 @@ fn storeMeshLod(
         remapped_indices.items,
     );
 
-    mesh.lods[mesh.num_lods] = .{
+    sub_mesh.lods[sub_mesh.lod_count] = .{
         .index_offset = @as(u32, @intCast(meshes_indices.items.len)),
         .index_count = @as(u32, @intCast(remapped_indices.items.len)),
         .vertex_offset = @as(u32, @intCast(meshes_vertices.items.len)),
         .vertex_count = @as(u32, @intCast(optimized_vertices.items.len)),
     };
 
-    mesh.num_lods += 1;
+    sub_mesh.lod_count += 1;
 
     // NOTE(gmodarelli): Flipping the triangles winding order so they are clock-wise
     var flipped_indices = std.ArrayList(rt.IndexType).init(arena);
@@ -473,7 +498,7 @@ fn storeMeshLod(
         max[2] = @max(max[2], vertex.position[2]);
     }
 
-    mesh.bounding_box = .{
+    sub_mesh.bounding_box = .{
         .min = min,
         .max = max,
     };

--- a/src/renderer/mesh_loader.zig
+++ b/src/renderer/mesh_loader.zig
@@ -146,7 +146,7 @@ pub fn parseMeshPrimitive(
             .position = positions.items[index],
             .normal = normals.items[index],
             .uv = uvs.items[index],
-            .tangent = if (has_tangents) tangents.items[index] else [4]f32{0.0, 0.0, 1.0, 0.0},
+            .tangent = if (has_tangents) tangents.items[index] else [4]f32{ 0.0, 0.0, 1.0, 0.0 },
             .color = [3]f32{ 1.0, 1.0, 1.0 },
         });
     }
@@ -154,7 +154,6 @@ pub fn parseMeshPrimitive(
     meshes_indices.appendSlice(indices.items) catch unreachable;
     return sub_mesh;
 }
-
 
 pub fn loadObjMeshFromFile(
     allocator: std.mem.Allocator,
@@ -315,15 +314,11 @@ pub fn loadObjMeshFromFile(
         inside_object = false;
     }
 
-
     // Update mesh bounding box (encapsulates all sub-meshes bounding boxes)
     var min = [3]f32{ std.math.floatMax(f32), std.math.floatMax(f32), std.math.floatMax(f32) };
     var max = [3]f32{ std.math.floatMin(f32), std.math.floatMin(f32), std.math.floatMin(f32) };
 
-    std.log.debug("Mesh: {s}", .{path});
     for (0..mesh.sub_mesh_count) |i| {
-        std.log.debug("Sub Mesh {d} - Min ({d:.3}, {d:.3}, {d:.3}) - Max ({d:.3}, {d:.3}, {d:.3})", .{i, mesh.sub_meshes[i].bounding_box.min[0], mesh.sub_meshes[i].bounding_box.min[1], mesh.sub_meshes[i].bounding_box.min[2], mesh.sub_meshes[i].bounding_box.max[0], mesh.sub_meshes[i].bounding_box.max[1], mesh.sub_meshes[i].bounding_box.max[2]});
-
         min[0] = @min(min[0], mesh.sub_meshes[i].bounding_box.min[0]);
         min[1] = @min(min[1], mesh.sub_meshes[i].bounding_box.min[1]);
         min[2] = @min(min[2], mesh.sub_meshes[i].bounding_box.min[2]);
@@ -337,7 +332,6 @@ pub fn loadObjMeshFromFile(
         .min = min,
         .max = max,
     };
-    std.log.debug("Mesh - Min ({d:.3}, {d:.3}, {d:.3}) - Max ({d:.3}, {d:.3}, {d:.3})\n", .{mesh.bounding_box.min[0], mesh.bounding_box.min[1], mesh.bounding_box.min[2], mesh.bounding_box.max[0], mesh.bounding_box.max[1], mesh.bounding_box.max[2]});
 
     return mesh;
 }

--- a/src/renderer/renderer_types.zig
+++ b/src/renderer/renderer_types.zig
@@ -32,7 +32,6 @@ pub const Mesh = struct {
     bounding_box: BoundingBox,
 };
 
-
 pub const BoundingBox = struct {
     min: [3]f32,
     max: [3]f32,

--- a/src/renderer/renderer_types.zig
+++ b/src/renderer/renderer_types.zig
@@ -5,7 +5,8 @@ const zwin32 = @import("zwin32");
 const d3d12 = zwin32.d3d12;
 const BufferHandle = @import("d3d12/buffer.zig").BufferHandle;
 
-pub const max_num_lods: u32 = 8;
+pub const lod_count_max: u32 = 8;
+pub const sub_mesh_count_max: u32 = 8;
 
 pub const MeshLod = struct {
     index_offset: u32,
@@ -14,27 +15,32 @@ pub const MeshLod = struct {
     vertex_count: u32,
 };
 
-pub const BoundingBox = struct {
-    min: [3]f32,
-    max: [3]f32,
-};
+pub const SubMesh = struct {
+    lod_count: u32,
+    lods: [lod_count_max]MeshLod,
 
-pub const BoundingBoxCoordinates = struct {
-    center: [3]f32,
-    radius: f32,
+    bounding_box: BoundingBox,
 };
 
 pub const Mesh = struct {
     vertex_buffer: BufferHandle,
     index_buffer: BufferHandle,
-    num_lods: u32,
-    lods: [max_num_lods]MeshLod,
-    bounding_box: BoundingBox,
 
-    pub fn calculateBoundingBoxCoordinates(mesh: *const Mesh, z_world: zm.Mat) BoundingBoxCoordinates {
-        var z_bb_min = zm.loadArr3(mesh.bounding_box.min);
+    sub_mesh_count: u32,
+    sub_meshes: [sub_mesh_count_max]SubMesh,
+
+    bounding_box: BoundingBox,
+};
+
+
+pub const BoundingBox = struct {
+    min: [3]f32,
+    max: [3]f32,
+
+    pub fn calculateBoundingBoxCoordinates(self: *const BoundingBox, z_world: zm.Mat) BoundingBoxCoordinates {
+        var z_bb_min = zm.loadArr3(self.min);
         z_bb_min[3] = 1.0;
-        var z_bb_max = zm.loadArr3(mesh.bounding_box.max);
+        var z_bb_max = zm.loadArr3(self.max);
         z_bb_max[3] = 1.0;
         const z_bb_min_ws = zm.mul(z_bb_min, z_world);
         const z_bb_max_ws = zm.mul(z_bb_max, z_world);
@@ -46,6 +52,11 @@ pub const Mesh = struct {
 
         return .{ .center = center, .radius = radius };
     }
+};
+
+pub const BoundingBoxCoordinates = struct {
+    center: [3]f32,
+    radius: f32,
 };
 
 pub const IndexType = u32;

--- a/src/systems/light_system.zig
+++ b/src/systems/light_system.zig
@@ -83,7 +83,7 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
     });
 
     while (entity_iter_directional_lights.next()) |comps| {
-        const z_forward = zm.rotate(comps.rotation.asZM(), zm.Vec{0, 0, 1, 0});
+        const z_forward = zm.rotate(comps.rotation.asZM(), zm.Vec{ 0, 0, 1, 0 });
         // std.log.debug("Directional light forward: {d:.3}, {d:.3}, {d:.3}\n", .{z_forward[0], z_forward[1], z_forward[2]});
 
         state.gfx.main_light = renderer_types.DirectionalLightGPU{
@@ -91,7 +91,6 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
             .radiance = [3]f32{ comps.light.radiance.r, comps.light.radiance.g, comps.light.radiance.b },
         };
     }
-
 
     var entity_iter_point_lights = state.query_point_lights.iterator(struct {
         transform: *const fd.Transform,

--- a/src/systems/static_mesh_renderer_system.zig
+++ b/src/systems/static_mesh_renderer_system.zig
@@ -45,6 +45,12 @@ const InstanceMaterial = struct {
     padding: u32,
 };
 
+const DrawCallInfo = struct {
+    mesh_handle: gfx.MeshHandle,
+    lod_index: u32,
+    sub_mesh_index: u32,
+};
+
 const max_instances = 1000000;
 const max_instances_per_draw_call = 4096;
 const max_draw_distance: f32 = 500.0;
@@ -61,6 +67,7 @@ const SystemState = struct {
     instance_transforms: std.ArrayList(InstanceTransform),
     instance_materials: std.ArrayList(InstanceMaterial),
     draw_calls: std.ArrayList(gfx.DrawCall),
+    draw_calls_info: std.ArrayList(DrawCallInfo),
     gpu_frame_profiler_index: u64 = undefined,
 
     query_camera: ecsu.Query,
@@ -115,6 +122,7 @@ pub fn create(name: IdLocal, allocator: std.mem.Allocator, gfxstate: *gfx.D3D12S
     };
 
     var draw_calls = std.ArrayList(gfx.DrawCall).init(allocator);
+    var draw_calls_info = std.ArrayList(DrawCallInfo).init(allocator);
     var instance_transforms = std.ArrayList(InstanceTransform).init(allocator);
     var instance_materials = std.ArrayList(InstanceMaterial).init(allocator);
 
@@ -142,6 +150,7 @@ pub fn create(name: IdLocal, allocator: std.mem.Allocator, gfxstate: *gfx.D3D12S
         .instance_transform_buffers = instance_transform_buffers,
         .instance_material_buffers = instance_material_buffers,
         .draw_calls = draw_calls,
+        .draw_calls_info = draw_calls_info,
         .instance_transforms = instance_transforms,
         .instance_materials = instance_materials,
         .query_camera = query_camera,
@@ -157,6 +166,7 @@ pub fn destroy(state: *SystemState) void {
     state.instance_transforms.deinit();
     state.instance_materials.deinit();
     state.draw_calls.deinit();
+    state.draw_calls_info.deinit();
     state.allocator.destroy(state);
 }
 
@@ -202,15 +212,9 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
     state.instance_transforms.clearRetainingCapacity();
     state.instance_materials.clearRetainingCapacity();
     state.draw_calls.clearRetainingCapacity();
+    state.draw_calls_info.clearRetainingCapacity();
 
-    var instance_count: u32 = 0;
-    var start_instance_location: u32 = 0;
-
-    var last_lod_index: u32 = 0;
-    var last_mesh_handle: gfx.MeshHandle = undefined;
-    var lod_index: u32 = 0;
-    var first_iteration = true;
-
+    // Iterate over all renderable meshes, perform frustum culling and generate instance transforms and materials
     while (entity_iter_mesh.next()) |comps| {
         var maybe_mesh = state.gfx.lookupMesh(comps.mesh.mesh_handle);
 
@@ -226,126 +230,123 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
             const z_bb_matrix = zm.mul(zm.scaling(bb_ws.radius, bb_ws.radius, bb_ws.radius), zm.translation(bb_ws.center[0], bb_ws.center[1], bb_ws.center[2]));
 
             // NOTE(gmodarelli): We're assuming all sub-meshes have the same number of LODs (which makes sense)
-            lod_index = pickLOD(camera_position, comps.transform.getPos00(), max_draw_distance, mesh.sub_meshes[0].lod_count);
+            const lod_index = pickLOD(camera_position, comps.transform.getPos00(), max_draw_distance, mesh.sub_meshes[0].lod_count);
 
-            if (first_iteration) {
-                last_mesh_handle = comps.mesh.mesh_handle;
-                last_lod_index = lod_index;
-                first_iteration = false;
-            }
-
-            if (isSameMeshHandle(last_mesh_handle, comps.mesh.mesh_handle) and lod_index == last_lod_index) {
-                if (instance_count < max_instances_per_draw_call) {
-                    instance_count += 1;
-                } else {
-                    state.draw_calls.append(.{
-                        .mesh_handle = comps.mesh.mesh_handle,
-                        .sub_mesh_index = 0,
-                        .lod_index = lod_index,
-                        .instance_count = instance_count,
-                        .start_instance_location = start_instance_location,
-                    }) catch unreachable;
-
-                    start_instance_location += instance_count;
-                    instance_count = 1;
-                }
-            } else if (isSameMeshHandle(last_mesh_handle, comps.mesh.mesh_handle) and lod_index != last_lod_index) {
-                state.draw_calls.append(.{
-                    .mesh_handle = last_mesh_handle,
-                    .sub_mesh_index = 0,
-                    .lod_index = last_lod_index,
-                    .instance_count = instance_count,
-                    .start_instance_location = start_instance_location,
-                }) catch unreachable;
-
-                start_instance_location += instance_count;
-                instance_count = 1;
-                last_lod_index = lod_index;
-            } else if (!isSameMeshHandle(last_mesh_handle, comps.mesh.mesh_handle)) {
-                state.draw_calls.append(.{
-                    .mesh_handle = last_mesh_handle,
-                    .sub_mesh_index = 0,
-                    .lod_index = last_lod_index,
-                    .instance_count = instance_count,
-                    .start_instance_location = start_instance_location,
-                }) catch unreachable;
-
-                start_instance_location += instance_count;
-                instance_count = 1;
-
-                last_mesh_handle = comps.mesh.mesh_handle;
-                lod_index = pickLOD(camera_position, comps.transform.getPos00(), max_draw_distance, mesh.sub_meshes[0].lod_count);
-
-                last_lod_index = lod_index;
-            }
+            var draw_call_info = DrawCallInfo{
+                .mesh_handle = comps.mesh.mesh_handle,
+                .lod_index = lod_index,
+                .sub_mesh_index = undefined,
+            };
 
             const invalid_texture_index = std.math.maxInt(u32);
-            state.instance_transforms.append(.{
-                .object_to_world = zm.transpose(z_world),
-                .bounding_sphere_matrix = zm.transpose(z_bb_matrix),
-            }) catch unreachable;
+            for (0..mesh.sub_mesh_count) |sub_mesh_index| {
+                draw_call_info.sub_mesh_index = @intCast(sub_mesh_index);
+                state.draw_calls_info.append(draw_call_info) catch unreachable;
 
-            var maybe_material = state.gfx.lookUpMaterial(comps.mesh.material_handles[0]);
-            if (maybe_material) |material| {
-                const albedo = blk: {
-                    if (state.gfx.lookupTexture(material.albedo)) |albedo| {
-                        break :blk albedo.persistent_descriptor.index;
-                    } else {
-                        break :blk invalid_texture_index;
-                    }
-                };
-
-                const arm = blk: {
-                    if (state.gfx.lookupTexture(material.arm)) |arm| {
-                        break :blk arm.persistent_descriptor.index;
-                    } else {
-                        break :blk invalid_texture_index;
-                    }
-                };
-
-                const normal = blk: {
-                    if (state.gfx.lookupTexture(material.normal)) |normal| {
-                        break :blk normal.persistent_descriptor.index;
-                    } else {
-                        break :blk invalid_texture_index;
-                    }
-                };
-
-                state.instance_materials.append(.{
-                    .albedo_color = [4]f32{ material.base_color.r, material.base_color.g, material.base_color.b, 1.0 },
-                    .roughness = material.roughness,
-                    .metallic = material.metallic,
-                    .normal_intensity = 1.0,
-                    .albedo_texture_index = albedo,
-                    .emissive_texture_index = invalid_texture_index,
-                    .normal_texture_index = normal,
-                    .arm_texture_index = arm,
-                    .padding = 42,
+                state.instance_transforms.append(.{
+                    .object_to_world = zm.transpose(z_world),
+                    .bounding_sphere_matrix = zm.transpose(z_bb_matrix),
                 }) catch unreachable;
-            } else {
-                state.instance_materials.append(.{
-                    .albedo_color = [4]f32{ 1.0, 0.0, 1.0, 1.0 },
-                    .roughness = 1.0,
-                    .metallic = 0.0,
-                    .normal_intensity = 1.0,
-                    .albedo_texture_index = invalid_texture_index,
-                    .emissive_texture_index = invalid_texture_index,
-                    .normal_texture_index = invalid_texture_index,
-                    .arm_texture_index = invalid_texture_index,
-                    .padding = 42,
-                }) catch unreachable;
+
+                var maybe_material = state.gfx.lookUpMaterial(comps.mesh.material_handles[sub_mesh_index]);
+                if (maybe_material) |material| {
+                    const albedo = blk: {
+                        if (state.gfx.lookupTexture(material.albedo)) |albedo| {
+                            break :blk albedo.persistent_descriptor.index;
+                        } else {
+                            break :blk invalid_texture_index;
+                        }
+                    };
+
+                    const arm = blk: {
+                        if (state.gfx.lookupTexture(material.arm)) |arm| {
+                            break :blk arm.persistent_descriptor.index;
+                        } else {
+                            break :blk invalid_texture_index;
+                        }
+                    };
+
+                    const normal = blk: {
+                        if (state.gfx.lookupTexture(material.normal)) |normal| {
+                            break :blk normal.persistent_descriptor.index;
+                        } else {
+                            break :blk invalid_texture_index;
+                        }
+                    };
+
+                    state.instance_materials.append(.{
+                        .albedo_color = [4]f32{ material.base_color.r, material.base_color.g, material.base_color.b, 1.0 },
+                        .roughness = material.roughness,
+                        .metallic = material.metallic,
+                        .normal_intensity = 1.0,
+                        .albedo_texture_index = albedo,
+                        .emissive_texture_index = invalid_texture_index,
+                        .normal_texture_index = normal,
+                        .arm_texture_index = arm,
+                        .padding = 42,
+                    }) catch unreachable;
+                } else {
+                    state.instance_materials.append(.{
+                        .albedo_color = [4]f32{ 1.0, 0.0, 1.0, 1.0 },
+                        .roughness = 1.0,
+                        .metallic = 0.0,
+                        .normal_intensity = 1.0,
+                        .albedo_texture_index = invalid_texture_index,
+                        .emissive_texture_index = invalid_texture_index,
+                        .normal_texture_index = invalid_texture_index,
+                        .arm_texture_index = invalid_texture_index,
+                        .padding = 42,
+                    }) catch unreachable;
+                }
             }
         }
     }
 
-    if (instance_count >= 1) {
-        state.draw_calls.append(.{
-            .mesh_handle = last_mesh_handle,
-            .sub_mesh_index = 0,
-            .lod_index = last_lod_index,
-            .instance_count = instance_count,
-            .start_instance_location = start_instance_location,
-        }) catch unreachable;
+    var start_instance_location: u32 = 0;
+    var current_draw_call: gfx.DrawCall = undefined;
+
+    for (state.draw_calls_info.items, 0..) |draw_call_info, i| {
+        if (i == 0) {
+            current_draw_call = .{
+                .mesh_handle = draw_call_info.mesh_handle,
+                .sub_mesh_index = draw_call_info.sub_mesh_index,
+                .lod_index = draw_call_info.lod_index,
+                .instance_count = 1,
+                .start_instance_location = start_instance_location,
+            };
+
+            start_instance_location += 1;
+
+            if (i == state.draw_calls_info.items.len - 1) {
+                state.draw_calls.append(current_draw_call) catch unreachable;
+            }
+            continue;
+        }
+
+        if (isSameMeshHandle(current_draw_call.mesh_handle, draw_call_info.mesh_handle) and current_draw_call.lod_index == draw_call_info.lod_index and current_draw_call.sub_mesh_index == draw_call_info.sub_mesh_index) {
+            current_draw_call.instance_count += 1;
+            start_instance_location += 1;
+
+            if (i == state.draw_calls_info.items.len - 1) {
+                state.draw_calls.append(current_draw_call) catch unreachable;
+            }
+        } else {
+            state.draw_calls.append(current_draw_call) catch unreachable;
+
+            current_draw_call = .{
+                .mesh_handle = draw_call_info.mesh_handle,
+                .sub_mesh_index = draw_call_info.sub_mesh_index,
+                .lod_index = draw_call_info.lod_index,
+                .instance_count = 1,
+                .start_instance_location = start_instance_location,
+            };
+
+            start_instance_location += 1;
+
+            if (i == state.draw_calls_info.items.len - 1) {
+                state.draw_calls.append(current_draw_call) catch unreachable;
+            }
+        }
     }
 
     state.gpu_frame_profiler_index = state.gfx.gpu_profiler.startProfile(state.gfx.gctx.cmdlist, "Static Mesh Renderer System");

--- a/src/systems/static_mesh_renderer_system.zig
+++ b/src/systems/static_mesh_renderer_system.zig
@@ -217,7 +217,7 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
         if (maybe_mesh) |mesh| {
             const z_world = zm.loadMat43(comps.transform.matrix[0..]);
 
-            const bb_ws = mesh.calculateBoundingBoxCoordinates(z_world);
+            const bb_ws = mesh.bounding_box.calculateBoundingBoxCoordinates(z_world);
             if (!cam.isVisible(bb_ws.center, bb_ws.radius)) {
                 continue;
             }
@@ -225,7 +225,8 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
             // Build bounding sphere matrix for debugging purpouses
             const z_bb_matrix = zm.mul(zm.scaling(bb_ws.radius, bb_ws.radius, bb_ws.radius), zm.translation(bb_ws.center[0], bb_ws.center[1], bb_ws.center[2]));
 
-            lod_index = pickLOD(camera_position, comps.transform.getPos00(), max_draw_distance, mesh.num_lods);
+            // NOTE(gmodarelli): We're assuming all sub-meshes have the same number of LODs (which makes sense)
+            lod_index = pickLOD(camera_position, comps.transform.getPos00(), max_draw_distance, mesh.sub_meshes[0].lod_count);
 
             if (first_iteration) {
                 last_mesh_handle = comps.mesh.mesh_handle;
@@ -239,6 +240,7 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
                 } else {
                     state.draw_calls.append(.{
                         .mesh_handle = comps.mesh.mesh_handle,
+                        .sub_mesh_index = 0,
                         .lod_index = lod_index,
                         .instance_count = instance_count,
                         .start_instance_location = start_instance_location,
@@ -250,6 +252,7 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
             } else if (isSameMeshHandle(last_mesh_handle, comps.mesh.mesh_handle) and lod_index != last_lod_index) {
                 state.draw_calls.append(.{
                     .mesh_handle = last_mesh_handle,
+                    .sub_mesh_index = 0,
                     .lod_index = last_lod_index,
                     .instance_count = instance_count,
                     .start_instance_location = start_instance_location,
@@ -261,6 +264,7 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
             } else if (!isSameMeshHandle(last_mesh_handle, comps.mesh.mesh_handle)) {
                 state.draw_calls.append(.{
                     .mesh_handle = last_mesh_handle,
+                    .sub_mesh_index = 0,
                     .lod_index = last_lod_index,
                     .instance_count = instance_count,
                     .start_instance_location = start_instance_location,
@@ -270,7 +274,7 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
                 instance_count = 1;
 
                 last_mesh_handle = comps.mesh.mesh_handle;
-                lod_index = pickLOD(camera_position, comps.transform.getPos00(), max_draw_distance, mesh.num_lods);
+                lod_index = pickLOD(camera_position, comps.transform.getPos00(), max_draw_distance, mesh.sub_meshes[0].lod_count);
 
                 last_lod_index = lod_index;
             }
@@ -281,7 +285,7 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
                 .bounding_sphere_matrix = zm.transpose(z_bb_matrix),
             }) catch unreachable;
 
-            var maybe_material = state.gfx.lookUpMaterial(comps.mesh.material_handle);
+            var maybe_material = state.gfx.lookUpMaterial(comps.mesh.material_handles[0]);
             if (maybe_material) |material| {
                 const albedo = blk: {
                     if (state.gfx.lookupTexture(material.albedo)) |albedo| {
@@ -337,6 +341,7 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
     if (instance_count >= 1) {
         state.draw_calls.append(.{
             .mesh_handle = last_mesh_handle,
+            .sub_mesh_index = 0,
             .lod_index = last_lod_index,
             .instance_count = instance_count,
             .start_instance_location = start_instance_location,
@@ -382,7 +387,7 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
                 });
 
                 const vertex_buffer = state.gfx.lookupBuffer(mesh.vertex_buffer);
-                const mesh_lod = mesh.lods[draw_call.lod_index];
+                const mesh_lod = mesh.sub_meshes[draw_call.sub_mesh_index].lods[draw_call.lod_index];
                 const mem = state.gfx.gctx.allocateUploadMemory(DrawUniforms, 1);
                 mem.cpu_slice[0].start_instance_location = draw_call.start_instance_location;
                 mem.cpu_slice[0].vertex_offset = @as(i32, @intCast(mesh_lod.vertex_offset));
@@ -405,8 +410,8 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
     state.gfx.gpu_profiler.endProfile(state.gfx.gctx.cmdlist, state.gpu_frame_profiler_index, state.gfx.gctx.frame_index);
 }
 
-fn pickLOD(camera_position: [3]f32, entity_position: [3]f32, draw_distance: f32, num_lods: u32) u32 {
-    if (num_lods == 1) {
+fn pickLOD(camera_position: [3]f32, entity_position: [3]f32, draw_distance: f32, lod_count: u32) u32 {
+    if (lod_count == 1) {
         return 0;
     }
 
@@ -418,15 +423,15 @@ fn pickLOD(camera_position: [3]f32, entity_position: [3]f32, draw_distance: f32,
     const t = squared_distance / squared_draw_distance;
 
     // TODO(gmodarelli): Store these LODs percentages in the Mesh itself.
-    // assert(num_lods == 4);
+    // assert(lod_count == 4);
     if (t <= 0.05) {
         return 0;
     } else if (t <= 0.1) {
-        return @min(num_lods - 1, 1);
+        return @min(lod_count - 1, 1);
     } else if (t <= 0.2) {
-        return @min(num_lods - 1, 2);
+        return @min(lod_count - 1, 2);
     } else {
-        return @min(num_lods - 1, 3);
+        return @min(lod_count - 1, 3);
     }
 }
 

--- a/src/systems/terrain_quad_tree.zig
+++ b/src/systems/terrain_quad_tree.zig
@@ -1092,10 +1092,10 @@ fn update(iter: *ecsu.Iterator(fd.NOCOMP)) void {
             const mesh = state.terrain_lod_meshes.items[quad.mesh_lod];
 
             state.draw_calls.append(.{
-                .index_count = mesh.lods[0].index_count,
+                .index_count = mesh.sub_meshes[0].lods[0].index_count,
                 .instance_count = 1,
-                .index_offset = mesh.lods[0].index_offset,
-                .vertex_offset = @as(i32, @intCast(mesh.lods[0].vertex_offset)),
+                .index_offset = mesh.sub_meshes[0].lods[0].index_offset,
+                .vertex_offset = @as(i32, @intCast(mesh.sub_meshes[0].lods[0].vertex_offset)),
                 .start_instance_location = start_instance_location,
             }) catch unreachable;
 

--- a/src/worldpatch/resource_manager.zig
+++ b/src/worldpatch/resource_manager.zig
@@ -156,27 +156,27 @@ pub const WorldPatchManager = struct {
     }
 
     pub fn registerRequester(self: *WorldPatchManager, id: IdLocal) RequesterId {
-        const requester_id = @intCast(u8, self.requesters.items.len);
+        const requester_id = @as(u8, @intCast(self.requesters.items.len));
         self.requesters.appendAssumeCapacity(id);
         return requester_id;
     }
 
     pub fn registerPatchType(self: *WorldPatchManager, patch_type: PatchType) PatchTypeId {
-        const patch_type_id = @intCast(u8, self.patch_types.items.len);
+        const patch_type_id = @as(u8, @intCast(self.patch_types.items.len));
         self.patch_types.appendAssumeCapacity(patch_type);
         return patch_type_id;
     }
 
     pub fn addLoadRequest(self: *WorldPatchManager, requester_id: RequesterId, patch_type_id: PatchTypeId, area: RequestArea, lod: LoD, prio: Priority) void {
-        const world_stride = self.lod_0_patch_size * std.math.pow(f32, @floatFromInt(f32, lod), 2);
+        const world_stride = self.lod_0_patch_size * std.math.pow(f32, @as(f32, @floatFromInt(lod)), 2);
         const world_x_begin = @divFloor(area.x, world_stride);
         const world_z_begin = @divFloor(area.z, world_stride);
         const world_x_end = @divFloor(area.x + area.width - 1, world_stride) + 1;
         const world_z_end = @divFloor(area.z + area.height - 1, world_stride) + 1;
-        const patch_x_begin = @intFromFloat(u16, @divExact(world_x_begin, world_stride));
-        const patch_z_begin = @intFromFloat(u16, @divExact(world_z_begin, world_stride));
-        const patch_x_end = @intFromFloat(u16, @divExact(world_x_end, world_stride));
-        const patch_z_end = @intFromFloat(u16, @divExact(world_z_end, world_stride));
+        const patch_x_begin = @as(u16, @intFromFloat(@divExact(world_x_begin, world_stride)));
+        const patch_z_begin = @as(u16, @intFromFloat(@divExact(world_z_begin, world_stride)));
+        const patch_x_end = @as(u16, @intFromFloat(@divExact(world_x_end, world_stride)));
+        const patch_z_end = @as(u16, @intFromFloat(@divExact(world_z_end, world_stride)));
 
         var patch_z = patch_z_begin;
         while (patch_z < patch_z_end) {
@@ -212,7 +212,7 @@ pub const WorldPatchManager = struct {
     }
 
     pub fn removeLoadRequest(self: *WorldPatchManager, requester_id: RequesterId, patch_type_id: PatchTypeId, area: RequestArea, lod: LoD) void {
-        const world_stride = self.lod_0_patch_size * std.math.pow(f32, @floatFromInt(f32, lod), 2);
+        const world_stride = self.lod_0_patch_size * std.math.pow(f32, @as(f32, @floatFromInt(lod)), 2);
         const world_x_begin = @divFloor(area.x, world_stride);
         const world_z_begin = @divFloor(area.z, world_stride);
         const world_x_end = @divFloor(area.x + area.width - 1, world_stride) + 1;


### PR DESCRIPTION
This PR introduces support for rendering sub-meshes. The support has been extended only to the Static Mesh Renderer System, while the Procedural Mesh System always renders the first sub-mesh.

I've also extended and simplified the draw calls batching algorithm so that it would support sub-meshes. I've only done this on the Static Mesh Renderer System, since we will soon get rid of the Procedural Mesh System anyway (I have a plan and I think I might open an Issue here to discuss it, unless you want to keep it in Discord).

Finally, I've replaced the untextured, small houses with Giulia's new textured medium house prefab.
<img width="798" alt="image" src="https://github.com/Srekel/elvengroin-legacy/assets/579525/a9c34800-b0f4-4c8b-b213-1ce014626af9">
