### PR TITLE
Offline generation: replace page_allocator with c_allocator

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -27,7 +27,7 @@ pub fn main() void {
     defer options.deinit();
 
     if (options.options.offlinegen) {
-        offline.generate();
+        offline.generate(std.heap.c_allocator);
     } else {
         game.run();
     }

--- a/src/offline_generation/main.zig
+++ b/src/offline_generation/main.zig
@@ -78,8 +78,8 @@ fn funcTemplateAdd(node: *g.Node, output: *g.NodeOutput, context: *g.GraphContex
 // ██║ ╚═╝ ██║██║  ██║██║██║ ╚████║
 // ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝
 
-pub fn generate() void {
-    zstbi.init(std.heap.page_allocator);
+pub fn generate(allocator: std.mem.Allocator) void {
+    zstbi.init(allocator);
     defer zstbi.deinit();
 
     const numberFunc = g.NodeFuncTemplate{
@@ -176,7 +176,7 @@ pub fn generate() void {
     var heightmapNode = g.Node{
         .name = IdLocal.init("Heightmap"),
         .template = heightmapNodeTemplate,
-        .allocator = std.heap.page_allocator,
+        .allocator = allocator,
         .output_artifacts = false,
     };
     heightmapNode.init();
@@ -194,7 +194,7 @@ pub fn generate() void {
         var node = g.Node{
             .name = IdLocal.init("Splatmap"),
             .template = splatmapNodeTemplate,
-            .allocator = std.heap.page_allocator,
+            .allocator = allocator,
             .output_artifacts = false,
         };
         node.init();
@@ -214,7 +214,7 @@ pub fn generate() void {
         var node = g.Node{
             .name = IdLocal.init("Heightmap Patch Artifact"),
             .template = patchArtifactNodeTemplate,
-            .allocator = std.heap.page_allocator,
+            .allocator = allocator,
             .output_artifacts = true,
         };
         node.init();
@@ -234,7 +234,7 @@ pub fn generate() void {
         var node = g.Node{
             .name = IdLocal.init("Splatmap Patch Artifact"),
             .template = patchArtifactNodeTemplate,
-            .allocator = std.heap.page_allocator,
+            .allocator = allocator,
             .output_artifacts = true,
         };
         node.init();
@@ -255,7 +255,7 @@ pub fn generate() void {
         var node = g.Node{
             .name = IdLocal.init("City"),
             .template = cityNodeTemplate,
-            .allocator = std.heap.page_allocator,
+            .allocator = allocator,
             .output_artifacts = true,
         };
         node.init();
@@ -272,7 +272,7 @@ pub fn generate() void {
         var node = g.Node{
             .name = IdLocal.init("Forest"),
             .template = forestNodeTemplate,
-            .allocator = std.heap.page_allocator,
+            .allocator = allocator,
             .output_artifacts = true,
         };
         node.init();
@@ -288,7 +288,7 @@ pub fn generate() void {
         var node = g.Node{
             .name = IdLocal.init("props"),
             .template = propsNodeTemplate,
-            .allocator = std.heap.page_allocator,
+            .allocator = allocator,
             .output_artifacts = true,
         };
         node.init();
@@ -321,7 +321,6 @@ pub fn generate() void {
     // var addInputValueB = addNode.getInput(IdLocal.init("valueB"));
     // addInputValueB.reference.set("pcg");
 
-    var allocator = std.heap.page_allocator;
     var graph = g.Graph{
         .nodes = std.ArrayList(g.Node).init(allocator),
     };


### PR DESCRIPTION
This change produces a >60% performance improvement in my (small sample-size) testing. Here are the results I got using the page_allocator, GPA and c_allocator.

<pre><span style="background-color:#4C566A"><font color="#E5E9F0"><b> I </b></font></span> ~/P/z/a/<b>elvengroin-legacy</b> (<font color="#A3BE8C">main</font> <font color="#BF616A">•</font>) &gt; <font color="#81A1C1">poop</font> <font color="#ECEFF4">zig-out-safe/bin/gen-</font><font color="#00A6B2">{</font><font color="#ECEFF4">page</font><font color="#00A6B2">,</font><font color="#ECEFF4">gpa</font><font color="#00A6B2">,</font><font color="#ECEFF4">c</font><font color="#00A6B2"><font color="#00A6B2">}</font>
<b>Benchmark 1 (3 runs)</b>: zig-out-safe/bin/gen-page
<b>  measurement                 </b><font color="#A3BE8C"><b>mean</b></font><b> ± </b><font color="#A3BE8C"><b>σ</b></font><b>                    </b><font color="#88C0D0"><b>min</b></font><b> … </b><font color="#B48EAD"><b>max</b></font><b>           </b><font color="#EBCB8B"><b>outliers</b></font><b>    delta</b>
  wall_time                 <font color="#A3BE8C">22.58s</font> ± <font color="#A3BE8C">145.719ms</font>        <font color="#88C0D0">22.411s</font> … <font color="#B48EAD">22.665s</font>        0 ( 0%)      0%
  peak_rss                    <font color="#A3BE8C">143M</font> ± <font color="#A3BE8C">55K</font>                 <font color="#88C0D0">143M</font> … <font color="#B48EAD">144M</font>           0 ( 0%)      0%
  cpu_cycles           <font color="#A3BE8C">27908624136</font> ± <font color="#A3BE8C">138134846</font>    <font color="#88C0D0">27790376893</font> … <font color="#B48EAD">28060453895</font>    0 ( 0%)      0%
  instructions         <font color="#A3BE8C">49706391089</font> ± <font color="#A3BE8C">40308472</font>     <font color="#88C0D0">49680154263</font> … <font color="#B48EAD">49752803565</font>    0 ( 0%)      0%
  cache_references       <font color="#A3BE8C">593134467</font> ± <font color="#A3BE8C">6479776</font>        <font color="#88C0D0">586175635</font> … <font color="#B48EAD">598994741</font>      0 ( 0%)      0%
  cache_misses            <font color="#A3BE8C">68071542</font> ± <font color="#A3BE8C">802815</font>          <font color="#88C0D0">67174206</font> … <font color="#B48EAD">68721712</font>       0 ( 0%)      0%
  branch_misses          <font color="#A3BE8C">176087461</font> ± <font color="#A3BE8C">807460</font>         <font color="#88C0D0">175592206</font> … <font color="#B48EAD">177019218</font>      0 ( 0%)      0%
<b>Benchmark 2 (3 runs)</b>: zig-out-safe/bin/gen-gpa
<b>  measurement                 </b><font color="#A3BE8C"><b>mean</b></font><b> ± </b><font color="#A3BE8C"><b>σ</b></font><b>                     </b><font color="#88C0D0"><b>min</b></font><b> … </b><font color="#B48EAD"><b>max</b></font><b>           </b><font color="#EBCB8B"><b>outliers</b></font><b>         delta</b>
  wall_time                <font color="#A3BE8C">12.254s</font> ± <font color="#A3BE8C">270.715ms</font>         <font color="#88C0D0">12.015s</font> … <font color="#B48EAD">12.548s</font>        0 ( 0%)    <font color="#EBCB8B">⚡</font><font color="#A3BE8C"> -45.7% ±  2.2%</font>
  peak_rss                    <font color="#A3BE8C">144M</font> ± <font color="#A3BE8C">37K</font>                  <font color="#88C0D0">144M</font> … <font color="#B48EAD">144M</font>           0 ( 0%)       + 0.1% ±  0.1%
  cpu_cycles           <font color="#A3BE8C">33226376178</font> ± <font color="#A3BE8C">797255550</font>     <font color="#88C0D0">32526451550</font> … <font color="#B48EAD">34094214490</font>    0 ( 0%)    💩<font color="#BF616A"> +19.1% ±  4.6%</font>
  instructions         <font color="#A3BE8C">65066101927</font> ± <font color="#A3BE8C">1564953545</font>    <font color="#88C0D0">63671010533</font> … <font color="#B48EAD">66758318223</font>    0 ( 0%)    💩<font color="#BF616A"> +30.9% ±  5.0%</font>
  cache_references       <font color="#A3BE8C">475254443</font> ± <font color="#A3BE8C">5325933</font>         <font color="#88C0D0">469299039</font> … <font color="#B48EAD">479560841</font>      0 ( 0%)    <font color="#EBCB8B">⚡</font><font color="#A3BE8C"> -19.9% ±  2.3%</font>
  cache_misses            <font color="#A3BE8C">55314288</font> ± <font color="#A3BE8C">74284</font>            <font color="#88C0D0">55229062</font> … <font color="#B48EAD">55365299</font>       0 ( 0%)    <font color="#EBCB8B">⚡</font><font color="#A3BE8C"> -18.7% ±  1.9%</font>
  branch_misses          <font color="#A3BE8C">295768302</font> ± <font color="#A3BE8C">15219422</font>        <font color="#88C0D0">281265232</font> … <font color="#B48EAD">311614983</font>      0 ( 0%)    💩<font color="#BF616A"> +68.0% ± 13.9%</font>
<b>Benchmark 3 (3 runs)</b>: zig-out-safe/bin/gen-c
<b>  measurement                 </b><font color="#A3BE8C"><b>mean</b></font><b> ± </b><font color="#A3BE8C"><b>σ</b></font><b>                    </b><font color="#88C0D0"><b>min</b></font><b> … </b><font color="#B48EAD"><b>max</b></font><b>           </b><font color="#EBCB8B"><b>outliers</b></font><b>         delta</b>
  wall_time                 <font color="#A3BE8C">8.493s</font> ± <font color="#A3BE8C">4.166ms</font>           <font color="#88C0D0">8.488s</font> … <font color="#B48EAD">8.495s</font>         0 ( 0%)    <font color="#EBCB8B">⚡</font><font color="#A3BE8C"> -62.4% ±  1.0%</font>
  peak_rss                    <font color="#A3BE8C">144M</font> ± <font color="#A3BE8C">99K</font>                 <font color="#88C0D0">144M</font> … <font color="#B48EAD">144M</font>           0 ( 0%)       + 0.5% ±  0.1%
  cpu_cycles           <font color="#A3BE8C">26321582791</font> ± <font color="#A3BE8C">76022184</font>     <font color="#88C0D0">26250969837</font> … <font color="#B48EAD">26402052644</font>    0 ( 0%)    <font color="#EBCB8B">⚡</font><font color="#A3BE8C"> - 5.7% ±  0.9%</font>
  instructions         <font color="#A3BE8C">53969214039</font> ± <font color="#A3BE8C">139685653</font>    <font color="#88C0D0">53845391518</font> … <font color="#B48EAD">54120641047</font>    0 ( 0%)    💩<font color="#BF616A"> + 8.6% ±  0.5%</font>
  cache_references       <font color="#A3BE8C">289295733</font> ± <font color="#A3BE8C">4139853</font>        <font color="#88C0D0">284523210</font> … <font color="#B48EAD">291917897</font>      0 ( 0%)    <font color="#EBCB8B">⚡</font><font color="#A3BE8C"> -51.2% ±  2.1%</font>
  cache_misses            <font color="#A3BE8C">29879522</font> ± <font color="#A3BE8C">1320683</font>         <font color="#88C0D0">28861449</font> … <font color="#B48EAD">31371843</font>       0 ( 0%)    <font color="#EBCB8B">⚡</font><font color="#A3BE8C"> -56.1% ±  3.6%</font>
  branch_misses          <font color="#A3BE8C">185461929</font> ± <font color="#A3BE8C">657109</font>         <font color="#88C0D0">185006147</font> … <font color="#B48EAD">186215166</font>      0 ( 0%)    💩<font color="#BF616A"> + 5.3% ±  0.9%</font>
</pre>