### PR TITLE
Rendering: fix the segmentation fault on exit

### DIFF
--- a/src/gfx_d3d12.zig
+++ b/src/gfx_d3d12.zig
@@ -837,6 +837,7 @@ pub const D3D12State = struct {
             self.gctx.addTransitionBarrier(resource, textureDesc.state);
 
             const t = Texture{
+                .resource_handle = resource,
                 .resource = self.gctx.lookupResource(resource).?,
                 .persistent_descriptor = srv_allocation,
             };
@@ -920,8 +921,12 @@ pub const D3D12State = struct {
             var texture = self.lookupTexture(handle);
 
             if (texture) |t| {
-                if (t.resource != null) {
-                    _ = t.resource.?.Release();
+                if (t.resource_handle) |resource_handle| {
+                    self.gctx.destroyResource(resource_handle);
+                    t.resource_handle = null;
+                    t.resource = null;
+                } else if (t.resource) |resource| {
+                    _ = resource.*.Release();
                     t.resource = null;
                 }
             }
@@ -1122,6 +1127,7 @@ pub const D3D12State = struct {
         );
 
         const texture = Texture{
+            .resource_handle = resource,
             .resource = self.gctx.lookupResource(resource).?,
             .persistent_descriptor = srv_allocation,
         };

--- a/src/renderer/d3d12/buffer.zig
+++ b/src/renderer/d3d12/buffer.zig
@@ -75,6 +75,8 @@ pub const BufferPool = struct {
         for (pool.buffers) |buffer| {
             if (buffer.size > 0) {
                 gctx.destroyResource(buffer.resource);
+                var b = @as(*Buffer, @constCast(&buffer));
+                b.size = 0;
             }
         }
 

--- a/src/renderer/renderer_types.zig
+++ b/src/renderer/renderer_types.zig
@@ -81,6 +81,7 @@ pub const TextureDesc = struct {
 };
 
 pub const Texture = struct {
+    resource_handle: ?zd3d12.ResourceHandle,
     resource: ?*d3d12.IResource,
     persistent_descriptor: zd3d12.PersistentDescriptor,
 };

--- a/src/systems/terrain_quad_tree.zig
+++ b/src/systems/terrain_quad_tree.zig
@@ -357,6 +357,7 @@ fn createTextureFromPixelBuffer(
     );
 
     return gfx.Texture{
+        .resource_handle = null,
         .resource = resource,
         .persistent_descriptor = srv_allocation,
     };

--- a/sync_external.py
+++ b/sync_external.py
@@ -69,7 +69,7 @@ def main():
     sync_lib(
         "zig-gamedev",
         "https://github.com/Srekel/zig-gamedev.git",
-        "0a7d8c27b7d7307d814ec51e7c69ef88ad738d33",
+        "af01493a51a5e975b8074631cde7b64392b93015",
     )
     # sync_lib(
     #     "zig-flecs",
@@ -83,7 +83,7 @@ def main():
     )
     # sync_lib("zls", "https://github.com/zigtools/zls.git", "949e4fe525abaf25699b7f15368ecdc49fd8b786")
 
-    sync_zig_exe("0.12.0-dev.817+54e7f58fc")
+    sync_zig_exe("0.12.0-dev.903+7aa85691b")
 
     os.chdir("..")
     print("Done syncing external!")


### PR DESCRIPTION
We store all the `Texture`s we use for the game in a `TexturePool`.
Each `Texture` contains a pointer to an `ID3D12Resource`, but sometimes we are not the owner of the pointer!

When we release all textures in the pool, we release all `ID3D12Resource`s, whether we own them or not. When we release an `ID3D12Resource` we don't own, `zd3d12` will try to release it as well, causing a segmentation fault.

For now I've fixed the issue by adding an optional `ResourceHandle` to the `Texture` struct. Now the `releaseAllTextures` function will call `zd3d12.destroyResource` is a `ResourceHandle` is present (these are managed textures), otherwise it'll release the resource itself (these are unmanaged textures).

Ideally we would have 2 separate texture pools, and 2 different struct: ManagedTexture and UnmanagedTexture.

But I need more time to fix the design :)
